### PR TITLE
docs: ReadTheDocs configuration

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,12 +18,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-include COPYING
-include *.rst
-include *.sh
-include pytest.ini
-recursive-include docs *.py
-recursive-include docs *.png
-recursive-include docs *.rst
-recursive-include docs *.txt
-recursive-include tests *.py
+-e .[all]


### PR DESCRIPTION
* Adds `docs/requirements.txt` so that ReadTheDocs can install all the
  prerequisites for building the autodoc parts of the documentation.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>