### PR TITLE
docs: unification of release note links

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -4,8 +4,9 @@ Components
 ==========
 
 REANA system is composed of multiple separated components that are developed
-independently. The components are usually published as Docker images. The
-components collaborate via REST APIs.
+independently. The components are usually published as Python packages (user
+client, administrator cluster management) or as Docker images (internal REANA
+components).
 
 reana-client
 ------------
@@ -13,7 +14,7 @@ reana-client
 REANA command line client for end users.
 
 - source code: `<https://github.com/reanahub/reana-client>`_
-- releases: `<https://github.com/reanahub/reana-client/releases>`_
+- release notes: `<https://github.com/reanahub/reana-client/releases>`_
 - known issues: `<https://github.com/reanahub/reana-client/issues>`_
 - documentation: `<https://reana-client.readthedocs.io/>`_
 
@@ -23,7 +24,7 @@ reana-cluster
 REANA component providing utilities to manage cluster instance.
 
 - source code: `<https://github.com/reanahub/reana-cluster>`_
-- releases: `<https://github.com/reanahub/reana-cluster/releases>`_
+- release notes: `<https://github.com/reanahub/reana-cluster/releases>`_
 - known issues: `<https://github.com/reanahub/reana-cluster/issues>`_
 - documentation: `<https://reana-cluster.readthedocs.io/>`_
 
@@ -33,7 +34,7 @@ reana-job-controller
 REANA component for running and managing jobs.
 
 - source code: `<https://github.com/reanahub/reana-job-controller>`_
-- releases: `<https://hub.docker.com/r/reanahub/reana-job-controller/tags>`_
+- release notes: `<https://github.com/reanahub/reana-job-controller/releases>`_
 - known issues: `<https://github.com/reanahub/reana-job-controller/issues>`_
 - documentation: `<https://reana-job-controller.readthedocs.io/>`_
 
@@ -43,7 +44,7 @@ reana-message-broker
 REANA component for messaging needs.
 
 - source code: `<https://github.com/reanahub/reana-message-broker>`_
-- releases: `<https://hub.docker.com/r/reanahub/reana-message-broker/tags>`_
+- release notes: `<https://github.com/reanahub/reana-message-broker/releases>`_
 - known issues: `<https://github.com/reanahub/reana-message-broker/issues>`_
 - documentation: `<https://reana-message-broker.readthedocs.io/>`_
 
@@ -53,7 +54,7 @@ reana-server
 REANA component providing API server replying to client queries.
 
 - source code: `<https://github.com/reanahub/reana-server>`_
-- releases: `<https://hub.docker.com/r/reanahub/reana-server/tags>`_
+- release notes: `<https://github.com/reanahub/reana-server/releases>`_
 - known issues: `<https://github.com/reanahub/reana-server/issues>`_
 - documentation: `<https://reana-server.readthedocs.io/>`_
 
@@ -63,17 +64,17 @@ reana-workflow-controller
 REANA component for running and managing workflows.
 
 - source code: `<https://github.com/reanahub/reana-workflow-controller>`_
-- releases: `<https://hub.docker.com/r/reanahub/reana-workflow-controller/tags>`_
+- release notes: `<https://github.com/reanahub/reana-workflow-controller/releases>`_
 - known issues: `<https://github.com/reanahub/reana-workflow-controller/issues>`_
 - documentation: `<https://reana-workflow-controller.readthedocs.io/>`_
 
 reana-workflow-engine-cwl
-----------------------------
+-------------------------
 
 REANA component for running CWL types of workflows.
 
 - source code: `<https://github.com/reanahub/reana-workflow-engine-cwl>`_
-- releases: `<https://hub.docker.com/r/reanahub/reana-workflow-engine-cwl/tags>`_
+- release notes: `<https://github.com/reanahub/reana-workflow-engine-cwl/releases>`_
 - known issues: `<https://github.com/reanahub/reana-workflow-engine-cwl/issues>`_
 - documentation: `<https://reana-workflow-engine-cwl.readthedocs.io/>`_
 
@@ -83,7 +84,7 @@ reana-workflow-engine-yadage
 REANA component for running Yadage types of workflows.
 
 - source code: `<https://github.com/reanahub/reana-workflow-engine-yadage>`_
-- releases: `<https://hub.docker.com/r/reanahub/reana-workflow-engine-yadage/tags>`_
+- release notes: `<https://github.com/reanahub/reana-workflow-engine-yadage/releases>`_
 - known issues: `<https://github.com/reanahub/reana-workflow-engine-yadage/issues>`_
 - documentation: `<https://reana-workflow-engine-yadage.readthedocs.io/>`_
 
@@ -93,6 +94,6 @@ reana-workflow-monitor
 REANA component permitting to monitor running workflows.
 
 - source code: `<https://github.com/reanahub/reana-workflow-monitor>`_
-- releases: `<https://hub.docker.com/r/reanahub/reana-workflow-monitor/tags>`_
+- release notes: `<https://github.com/reanahub/reana-workflow-monitor/releases>`_
 - known issues: `<https://github.com/reanahub/reana-workflow-monitor/issues>`_
 - documentation: `<https://reana-workflow-monitor.readthedocs.io/>`_


### PR DESCRIPTION
* Unifies release note links to point to GitHub where the release notes are
  presented in a readable manner for all components. (closes #50)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>