### PR TITLE
cli: filter components in docker commands

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,9 +24,11 @@
 
 from __future__ import absolute_import, print_function
 
+import os
+
 
 def test_shorten_component_name():
-    """Test shortening of component names."""
+    """Tests for shorten_component_name()."""
     from reana.cli import shorten_component_name
     for (name_long, name_short) in (
             ('', ''),
@@ -34,3 +36,28 @@ def test_shorten_component_name():
             ('reana-job-controller', 'r-j-controller'),
     ):
         assert name_short == shorten_component_name(name_long)
+
+
+def test_is_component_dockerised():
+    """Tests for is_component_dockerised()."""
+    from reana.cli import is_component_dockerised
+    if os.environ.get('REANA_SRCDIR'):
+        assert is_component_dockerised('reana-workflow-controller') is True
+        assert is_component_dockerised('reana-cluster') is False
+
+
+def test_select_components():
+    """Tests for select_components()."""
+    from reana.cli import select_components, REPO_LIST_ALL, REPO_LIST_CLUSTER
+    for (input_value, output_expected) in (
+            (['reana-job-controller', ], ['reana-job-controller', ]),
+            (['reana-job-controller', 'reana', ],
+             ['reana-job-controller', 'reana, ']),
+            (['cluster', ], REPO_LIST_CLUSTER),
+            (['cluster', 'reana', ], REPO_LIST_CLUSTER),
+            (['all', ], REPO_LIST_ALL),
+            (['all', 'reana', ], REPO_LIST_ALL),
+            (['all', 'cluster', 'reana'], REPO_LIST_ALL),
+    ):
+        output_obtained = select_components(input_value)
+        assert output_obtained.sort() == output_expected.sort()


### PR DESCRIPTION
* Filters away some components that are not dockerisable (such as
  `reana-cluster`) when attempting to execute docker commands
  (such as `reana docker-build`).

* Adds tests for select_components() as well.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>