### PR TITLE
cli: richer component name specification options

### DIFF
--- a/reana/cli.py
+++ b/reana/cli.py
@@ -40,6 +40,7 @@ REPO_LIST_ALL = [
     'reana-demo-alice-lego-train-test-run',
     'reana-demo-atlas-recast',
     'reana-demo-bsm-search',
+    'reana-demo-cms-h4l',
     'reana-demo-helloworld',
     'reana-demo-lhcb-d2pimumu',
     'reana-demo-root6-roofit',
@@ -123,17 +124,29 @@ def cli():  # noqa: D301
         $ reana-cluster -f reana-cluster-latest.yaml init
         $ # we now have REANA cluster running "master" versions of components
 
+    How to test one component pull request:
+
+    .. code-block:: console
+
+        \b
+        $ cd reana-job-controller
+        $ reana git-checkout -b . 72 --fetch
+        $ reana docker-build -c .
+        $ kubectl delete pod -l app=job-controller
+        $ kubectl get pods
+        $ # we can now try to run an example
+
     How to test multiple component branches:
 
     .. code-block:: console
 
         \b
-        $ reana git-checkout -b reana-job-controller 82
-        $ reana git-checkout -b reana-workflow-controller 112
+        $ reana git-checkout -b reana-job-controller 72
+        $ reana git-checkout -b reana-workflow-controller 98
         $ reana git-status
         $ reana docker-build
-        $ kubectl delete pod job-controller-65f87df9df-ht459
-        $ kubectl delete pod workflow-controller-76d7b87887-2b64n
+        $ kubectl delete pod -l app=job-controller
+        $ kubectl delete pod -l app=workflow-controller
         $ kubectl get pods
         $ # we can now try to run an example
 
@@ -153,8 +166,58 @@ def cli():  # noqa: D301
     pass
 
 
+def shorten_component_name(component):
+    """Return canonical short version of the component name.
+
+    Example: reana-job-controller -> r-j-controller
+
+    :param component: standard component name
+    :type component: str
+
+    :return: short component name
+    :rtype: str
+    """
+    short_name = ''
+    parts = component.split('-')
+    for part in parts[:-1]:
+        short_name += part[0] + '-'
+    short_name += parts[-1]
+    return short_name
+
+
+def find_standard_component_name(short_component_name):
+    """Return standard component name corresponding to the short name.
+
+    Example: r-j-controller -> reana-job-controller
+
+    :param short_component_name: short component name
+    :type component: str
+
+    :return: standard component name
+    :rtype: str
+
+    :raise: exception in case more than one is found
+    """
+    output = []
+    for component in REPO_LIST_ALL:
+        component_short_name = shorten_component_name(component)
+        if component_short_name == short_component_name:
+            output.append(component)
+    if len(output) == 1:
+        return output[0]
+    raise Exception('Component name {0} cannot be uniquely mapped.'.format(
+        'short_component_name'))
+
+
 def get_srcdir(component=''):
-    """Return source code directory for the given component."""
+    """Return source code directory of the given REANA component.
+
+    :param component: standard component name
+    :type component: str
+
+    :return: source code directory for given component
+    :rtype: str
+    """
     if not SRCDIR:
         click.echo('Please set environment variable REANA_SRCDIR'
                    ' to the directory that will contain'
@@ -169,20 +232,40 @@ def get_srcdir(component=''):
 
 
 def get_current_branch(srcdir):
-    """Return current Git branch name checked out in the given directory."""
+    """Return current Git branch name checked out in the given directory.
+
+    :param component: standard component name
+    :type component: str
+
+    :return: checkout out branch in the component source code directory
+    :rtype: str
+    """
     os.chdir(srcdir)
     return subprocess.getoutput('git branch 2>/dev/null | '
                                 'grep "^*" | colrm 1 2')
 
 
 def select_components(components):
-    """Return expanded and simplified component list based on input values.
+    """Return expanded and unified component name list based on input values.
 
-    The input value is list. Each item may be containing (name, 'CLUSTER',
-    'ALL') where name is a component name, 'CLUSTER' will expand to cover all
-    REANA cluster components, 'ALL' will expand to include all REANA
-    repositories.
+    :param components: A list of component name that may consist of:
+                          * (1) standard component names such as
+                                'reana-job-controller';
+                          * (2) short component name such as 'r-j-controller';
+                          * (3) special value '.' indicating component of the
+                                current working directory;
+                          * (4) special value 'CLUSTER' that will expand to
+                                cover all REANA cluster components;
+                          * (5) special value 'ALL' that will expand to include
+                                all REANA repositories.
+    :type components: list
+
+    :return: Unique standard component names.
+    :rtype: list
+
     """
+    short_component_names = [shorten_component_name(name)
+                             for name in REPO_LIST_ALL]
     output = set([])
     for component in components:
         if component == 'ALL':
@@ -191,8 +274,17 @@ def select_components(components):
         elif component == 'CLUSTER':
             for repo in REPO_LIST_CLUSTER:
                 output.add(repo)
-        else:
+        elif component == '.':
+            cwd = os.path.basename(os.getcwd())
+            output.add(cwd)
+        elif component in REPO_LIST_ALL:
             output.add(component)
+        elif component in short_component_names:
+            component_standard_name = find_standard_component_name(component)
+            output.add(component_standard_name)
+        else:
+            display_message('Ignoring unknown component {0}.'.format(
+                component))
     return list(output)
 
 
@@ -202,29 +294,27 @@ def is_component_dockerised(component):
     Useful to skip some docker-related commands for those components that are
     not concerned, such as building Docker images for `reana-cluster` that does
     not provide any.
+
+    :param component: standard component name
+    :type component: str
+
+    :return: True/False whether the component is dockerisable
+    :rtype: bool
     """
     if os.path.exists(get_srcdir(component) + os.sep + 'Dockerfile'):
         return True
     return False
 
 
-def shorten_component_name(component):
-    """Return shorter version of the component name.
-
-    Example: reana-job-controller -> r-j-controller
-    """
-    short_name = ''
-    parts = component.split('-')
-    for part in parts[:-1]:
-        short_name += part[0] + '-'
-    short_name += parts[-1]
-    return short_name
-
-
 def run_command(cmd, component=''):
     """Run given command in the given component source directory.
 
     Exit in case of troubles.
+
+    :param cmd: shell command to run
+    :param component: standard component name
+    :type cmd: str
+    :type component: str
     """
     click.secho('[{0}] {1}'.format(component, cmd), bold=True)
     if component:
@@ -236,7 +326,13 @@ def run_command(cmd, component=''):
 
 
 def display_message(msg, component=''):
-    """Display message in a similar style as run_command()."""
+    """Display message in a similar style as run_command().
+
+    :param msg: message to display
+    :param component: standard component name
+    :type msg: str
+    :type component: str
+    """
     click.secho('[{0}] {1}'.format(component, msg), bold=True)
 
 
@@ -254,17 +350,28 @@ def help():
 
 
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
-              help='Which components? [name|CLUSTER|ALL]')
+              help='Which components? [shortname|name|.|CLUSTER|ALL]')
 @click.option('--browser', '-b', default='firefox',
               help='Which browser to use? [firefox]')
 @cli.command(name='git-fork')
-def git_fork(component, browser):
+def git_fork(component, browser):  # noqa: D301
     """Display commands to fork REANA source code repositories on GitHub.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :param browser: The web browser to use. [default=firefox]
+    :type component: str
+    :type browser: str
     """
     components = select_components(component)
     if components:
@@ -286,16 +393,26 @@ def git_fork(component, browser):
 @click.option('--user', '-u', default=GITHUB_USER,
               help='GitHub user name [{0}]'.format(GITHUB_USER))
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
-              help='Which components? [name|CLUSTER|ALL]')
+              help='Which components? [shortname|name|.|CLUSTER|ALL]')
 @cli.command(name='git-clone')
-def git_clone(user, component):
+def git_clone(user, component):  # noqa: D301
     """Clone REANA source repositories from GitHub.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
-
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :param user: The GitHub user name. [default=$REANA_GITHUB_USER]
+    :type component: str
+    :type user: str
     """
     if not GITHUB_USER:
         click.echo('Please set environment variable REANA_GITHUB_USER to your'
@@ -317,15 +434,24 @@ def git_clone(user, component):
 
 
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
-              help='Which components? [name|CLUSTER|ALL]')
+              help='Which components? [shortname|name|.|CLUSTER|ALL]')
 @cli.command(name='git-status')
-def git_status(component):
+def git_status(component):  # noqa: D301
     """Report status of REANA source repositories.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :type component: str
     """
     components = select_components(component)
     for component in components:
@@ -338,18 +464,27 @@ def git_status(component):
 
 
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
-              help='Which components? [name|CLUSTER|ALL]')
+              help='Which components? [shortname|name|.|CLUSTER|ALL]')
 @cli.command(name='git-clean')
-def git_clean(component):
+def git_clean(component):  # noqa: D301
     """Clean REANA source repository code tree.
 
     Removes pyc, eggs, _build and other leftover friends.
     Less aggressive then "git clean -x".
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :type component: str
     """
     components = select_components(component)
     for component in components:
@@ -367,36 +502,55 @@ def git_clean(component):
               help='Which PR? [number component]')
 @click.option('--fetch', is_flag=True, default=False)
 @cli.command(name='git-checkout')
-def git_checkout(branch, fetch):
+def git_checkout(branch, fetch):  # noqa: D301
     """Check out local branch corresponding to a component pull request.
 
-    For example, ``-b reana-job-controler 82`` will create a local branch
-    called ``pr-82`` in the reana-job-component source code directory.
+    The ``-b`` option can be repetitive to check out several pull requests in
+    several repositories at the same time.
 
-    The options can be repetitive to check out several pull requests in several
-    repositories at the same time.
-
-    The option ``--fetch`` fetches upstream first.
+    \b
+    :param branch: The option ``branch`` can be repeated. The value consist of
+                   two strings specifying the component name and the pull
+                   request number. For example, ``-b reana-job-controler 72``
+                   will create a local branch called ``pr-72`` in the
+                   reana-job-component source code directory.
+    :param fetch: Should we fetch latest upstream first? [default=False]
+    :type component: str
+    :type fetch: bool
     """
     for cpr in branch:
         component, pull_request = cpr
-        if fetch:
-            cmd = 'git fetch upstream'
+        component = select_components([component, ])[0]
+        if component in REPO_LIST_ALL:
+            if fetch:
+                cmd = 'git fetch upstream'
+                run_command(cmd, component)
+            cmd = 'git checkout -b pr-{0} upstream/pr/{0}'.format(pull_request)
             run_command(cmd, component)
-        cmd = 'git checkout -b pr-{0} upstream/pr/{0}'.format(pull_request)
-        run_command(cmd, component)
+        else:
+            msg = 'Ignoring unknown component.'
+            display_message(msg, component)
 
 
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
-              help='Which components? [name|CLUSTER|ALL]')
+              help='Which components? [shortname|name|.|CLUSTER|ALL]')
 @cli.command(name='git-fetch')
-def git_fetch(component):
+def git_fetch(component):  # noqa: D301
     """Fetch REANA upstream source code repositories without upgrade.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :type component: str
     """
     for component in select_components(component):
         cmd = 'git fetch upstream'
@@ -404,15 +558,24 @@ def git_fetch(component):
 
 
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
-              help='Which components? [name|CLUSTER|ALL]')
+              help='Which components? [shortname|name|.|CLUSTER|ALL]')
 @cli.command(name='git-upgrade')
-def git_upgrade(component):
+def git_upgrade(component):  # noqa: D301
     """Upgrade REANA local source code repositories.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :type component: str
     """
     for component in select_components(component):
         for cmd in ['git fetch upstream',
@@ -424,15 +587,24 @@ def git_upgrade(component):
 
 
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
-              help='Which components? [name|CLUSTER|ALL]')
+              help='Which components? [shortname|name|.|CLUSTER|ALL]')
 @cli.command(name='git-diff')
-def git_diff(component):
+def git_diff(component):  # noqa: D301
     """Diff checked-out REANA local source code repositories.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :type component: str
     """
     for component in select_components(component):
         for cmd in ['git diff master', ]:
@@ -442,13 +614,22 @@ def git_diff(component):
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
               help='Which components? [name|CLUSTER]')
 @cli.command(name='git-push')
-def git_push(full, component):
+def git_push(full, component):  # noqa: D301
     """Push REANA local repositories to GitHub origin.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :type component: str
     """
     components = select_components(component)
     for component in components:
@@ -464,13 +645,28 @@ def git_push(full, component):
               help='Which components? [name|CLUSTER]')
 @click.option('--no-cache', is_flag=True)
 @cli.command(name='docker-build')
-def docker_build(user, tag, component, no_cache):
+def docker_build(user, tag, component, no_cache):  # noqa: D301
     """Build REANA component images.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :param user: DockerHub organisation or user name. [default=reanahub]
+    :param tag: Docker tag to use. [default=latest]
+    :param no_cache: Flag instructing to avoid using cache. [default=False]
+    :type component: str
+    :type user: str
+    :type tag: str
+    :type no_cache: bool
     """
     components = select_components(component)
     for component in components:
@@ -491,8 +687,12 @@ def docker_build(user, tag, component, no_cache):
 @click.option('--user', '-u', default='reanahub',
               help='DockerHub user name [reanahub]')
 @cli.command(name='docker-images')
-def docker_images(user):
-    """List REANA component images."""
+def docker_images(user):  # noqa: D301
+    """List REANA component images.
+
+    :param user: DockerHub user name. [default=reanahub]
+    :type user: str
+    """
     cmd = 'docker images | grep {0}'.format(user)
     run_command(cmd)
 
@@ -504,13 +704,26 @@ def docker_images(user):
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
               help='Which components? [name|CLUSTER]')
 @cli.command(name='docker-rmi')
-def docker_rmi(user, tag, component):
+def docker_rmi(user, tag, component):  # noqa: D301
     """Remove REANA component images.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :param user: DockerHub organisation or user name. [default=reanahub]
+    :param tag: Docker tag to use. [default=latest]
+    :type component: str
+    :type user: str
+    :type tag: str
     """
     components = select_components(component)
     for component in components:
@@ -530,13 +743,26 @@ def docker_rmi(user, tag, component):
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
               help='Which components? [name|CLUSTER]')
 @cli.command(name='docker-push')
-def docker_push(user, tag, component):
+def docker_push(user, tag, component):  # noqa: D301
     """Push REANA component images to DockerHub.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :param user: DockerHub organisation or user name. [default=reanahub]
+    :param tag: Docker tag to use. [default=latest]
+    :type component: str
+    :type user: str
+    :type tag: str
     """
     components = select_components(component)
     for component in components:
@@ -556,17 +782,30 @@ def docker_push(user, tag, component):
 @click.option('--component', '-c', multiple=True, default=['CLUSTER'],
               help='Which components? [name|CLUSTER]')
 @cli.command(name='docker-pull')
-def docker_pull(user, tag, component):
+def docker_pull(user, tag, component):  # noqa: D301
     """Pull REANA component images from DockerHub.
 
-    The option ``component`` can be repeated and the value can be a name such
-    as 'reana-job-controller', or a special value 'CLUSTER' meaning all
-    cluster-related components, or special value 'ALL' meaning all REANA
-    repositories. [default=CLUSTER]
+    \b
+    :param components: The option ``component`` can be repeated. The value may
+                       consist of:
+                         * (1) standard component name such as
+                               'reana-job-controller';
+                         * (2) short component name such as 'r-j-controller';
+                         * (3) special value '.' indicating component of the
+                               current working directory;
+                         * (4) special value 'CLUSTER' that will expand to
+                               cover all REANA cluster components [default];
+                         * (5) special value 'ALL' that will expand to include
+                               all REANA repositories.
+    :param user: DockerHub organisation or user name. [default=reanahub]
+    :param tag: Docker tag to use. [default=latest]
+    :type component: str
+    :type user: str
+    :type tag: str
     """
     components = select_components(component)
     for component in components:
-        if not is_component_dockerised(component):
+        if is_component_dockerised(component):
             cmd = 'docker pull {0}/{1}:{2}'.format(user, component, tag)
             run_command(cmd, component)
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,14 +50,47 @@ def test_select_components():
     """Tests for select_components()."""
     from reana.cli import select_components, REPO_LIST_ALL, REPO_LIST_CLUSTER
     for (input_value, output_expected) in (
-            (['reana-job-controller', ], ['reana-job-controller', ]),
+            # regular operation:
+            (['reana-job-controller', ],
+             ['reana-job-controller', ]),
             (['reana-job-controller', 'reana', ],
              ['reana-job-controller', 'reana, ']),
+            # special value: '.'
+            (['.', ], [os.path.basename(os.getcwd()), ]),
+            # special value: 'cluster'
             (['cluster', ], REPO_LIST_CLUSTER),
-            (['cluster', 'reana', ], REPO_LIST_CLUSTER),
+            # special value: 'ALL'
             (['all', ], REPO_LIST_ALL),
+            # bad values:
+            (['nonsense', ], []),
+            (['nonsense', 'reana', ], ['reana', ]),
+            # output uniqueness:
             (['all', 'reana', ], REPO_LIST_ALL),
+            (['cluster', 'reana', ], REPO_LIST_CLUSTER),
             (['all', 'cluster', 'reana'], REPO_LIST_ALL),
     ):
         output_obtained = select_components(input_value)
         assert output_obtained.sort() == output_expected.sort()
+
+
+def test_find_standard_component_name():
+    """Tests for find_standard_component_name()."""
+    from reana.cli import find_standard_component_name
+    for (input_value, output_expected) in (
+            ('reana', 'reana'),
+            ('r-server', 'reana-server'),
+            ('r-j-controller', 'reana-job-controller'),
+    ):
+        output_obtained = find_standard_component_name(input_value)
+        assert output_obtained == output_expected
+
+
+def test_uniqueness_of_short_names():
+    """Test whether all shortened component names are unique."""
+    from reana.cli import shorten_component_name, REPO_LIST_ALL
+    short_names = []
+    for repo in REPO_LIST_ALL:
+        short_name = shorten_component_name(repo)
+        if short_name in short_names:
+            raise Exception('Found ')
+        short_names.append(short_name)


### PR DESCRIPTION
* Adds more options on how to specify component names for the `reana` helper
  script. Accepts now also the canonical short names (`r-j-controller`) and the
  current working directory based name (`.`).

* Enriches `reana` helper script documentation to cover all CLI options.

* Adds new example repository `reana-demo-cms-h4l`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>