### PR TITLE
cli: run-example code and data upload

### DIFF
--- a/reana/cli.py
+++ b/reana/cli.py
@@ -1037,7 +1037,7 @@ def run_example(component, workflow_engine, output, sleep):  # noqa: D301
             for cmd in [
                 'reana-client create -f {0} -n {1}'.format(
                     reana_yaml[workflow_engine], workflow_name),
-                'reana-client upload ./code ./inputs -w {0}'.format(
+                'reana-client upload ./code ./data -w {0}'.format(
                     workflow_name),
                 'reana-client start -w {0}'.format(
                     workflow_name),


### PR DESCRIPTION
* Amends ``run-example`` instructions how to upload code and data following up
  the new convention in REANA demo examples.
  (see reanahub/reana-demo-worldpopulation#23)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>