### PR TITLE
cli: configurable outputs for run-example

### DIFF
--- a/reana/cli.py
+++ b/reana/cli.py
@@ -90,6 +90,14 @@ COMPONENT_PODS = {
     'reana-workflow-engine-yadage': 'yadage-default-worker',
 }
 
+EXAMPLE_OUTPUTS = {
+    'reana-demo-helloworld': ('greetings.txt',),
+    'reana-demo-bsm-search': ('prefit.pdf', 'postfit.pdf'),
+    'reana-demo-alice-lego-train-test-run': ('plot.pdf',),
+    'reana-demo-atlas-recast': ('pre.png', 'limit.png', 'limit_data.json'),
+    '*': ('plot.png',)
+}
+
 
 @click.group()
 def cli():  # noqa: D301
@@ -438,6 +446,19 @@ def display_message(msg, component=''):
     :type component: str
     """
     click.secho('[{0}] {1}'.format(component, msg), bold=True)
+
+
+def get_default_output_for_example(example):
+    """Return default output file name for given example.
+
+    :param example: name of the component
+    :return: Tuple with output file name(s)
+    """
+    try:
+        output = EXAMPLE_OUTPUTS[example]
+    except KeyError:
+        output = EXAMPLE_OUTPUTS['*']
+    return output
 
 
 @cli.command()
@@ -993,8 +1014,7 @@ def setup_environment():  # noqa: D301
               default=['cwl', 'serial', 'yadage'],
               help='Which workflow engine to run? [cwl,serial,yadage]')
 @click.option('--output', '-o', multiple=True,
-              default=['plot.png'],
-              help='Expected output file? [plot.png]')
+              help='Expected output file?')
 @click.option('--sleep', '-s', default=60,
               help='How much seconds to wait for results? [60]')
 @cli.command(name='run-example')
@@ -1053,6 +1073,7 @@ def run_example(component, workflow_engine, output, sleep):  # noqa: D301
             ]:
                 run_command(cmd, component)
             # verify output file presence:
+            output = output or get_default_output_for_example(component)
             for output_file in output:
                 cmd = 'reana-client list -w {0} | grep -q {1}'.format(
                     workflow_name, output_file)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,18 @@ def test_shorten_component_name():
         assert name_short == shorten_component_name(name_long)
 
 
+def test_get_default_output_for_example():
+    """Tests for get_default_output_for_example()."""
+    from reana.cli import get_default_output_for_example
+    for (example, output) in (
+            ('', ('plot.png',)),
+            ('reana-demo-helloworld', ('greetings.txt',)),
+            ('reana-demo-root6-roofit', ('plot.png',)),
+            ('reana-demo-alice-lego-train-test-run', ('plot.pdf', )),
+    ):
+        assert output == get_default_output_for_example(example)
+
+
 def test_is_component_dockerised():
     """Tests for is_component_dockerised()."""
     from reana.cli import is_component_dockerised


### PR DESCRIPTION
Adds default output files in run-example function.
(Closes 98)

Signed-off-by: Jan Okraska <jan.okraska@cern.ch>