### PR TITLE
make: configurable CPU, RAM, and disk size for minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@
 GITHUB_USER ?= anonymous
 MINIKUBE_DRIVER ?= kvm2
 MINIKUBE_PROFILE ?= minikube
+MINIKUBE_CPUS ?= 2
+MINIKUBE_MEMORY ?= 3072
+MINIKUBE_DISKSIZE ?= 40g
 TIME_SLEEP ?= 40
 VENV_NAME ?= reana
 
@@ -57,7 +60,7 @@ endif
 ifndef HAS_MINIKUBE
 	$(error "Please install Minikube v0.34 or higher")
 endif
-	minikube status --profile ${MINIKUBE_PROFILE} || minikube start --profile ${MINIKUBE_PROFILE} --vm-driver ${MINIKUBE_DRIVER} --feature-gates="TTLAfterFinished=true"
+	minikube status --profile ${MINIKUBE_PROFILE} || minikube start --profile ${MINIKUBE_PROFILE} --vm-driver ${MINIKUBE_DRIVER} --cpus ${MINIKUBE_CPUS} --memory ${MINIKUBE_MEMORY} --disk-size ${MINIKUBE_DISKSIZE} --feature-gates="TTLAfterFinished=true"
 	test -e ${HOME}/.virtualenvs/${VENV_NAME}/bin/activate || virtualenv ${HOME}/.virtualenvs/${VENV_NAME}
 
 clone: # Clone REANA source code repositories locally.


### PR DESCRIPTION
* In order to test bigger Docker images such as CMSSW, it is useful to allow
  Minikube to have bigger RAM and disk size.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>