### PR TITLE
cli: removal of cwl-default-worker

### DIFF
--- a/reana/cli.py
+++ b/reana/cli.py
@@ -84,7 +84,6 @@ WORKFLOW_ENGINE_LIST_ALL = [
 ]
 
 COMPONENT_PODS = {
-    'reana-workflow-engine-cwl': 'cwl-default-worker',
     'reana-db': 'db',
     'reana-message-broker': 'message-broker',
     'reana-server': 'server',


### PR DESCRIPTION
* Removes forgotten `cwl-default-worker` as well. (addresses #169)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>