### PR TITLE
cli: version command help message

### DIFF
--- a/reana/cli.py
+++ b/reana/cli.py
@@ -595,7 +595,7 @@ def get_current_version(component, dirty=False):
 
 @cli.command()
 def version():
-    """Return REANA version."""
+    """Show version."""
     from reana.version import __version__
     click.echo(__version__)
 

--- a/reana/version.py
+++ b/reana/version.py
@@ -13,4 +13,4 @@ This file is imported by ``reana.__init__`` and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.5.0"
+__version__ = "0.6.0.dev20190730"


### PR DESCRIPTION
* Makes ``reana-dev version`` command help message consistent with newly
  introduced ``reana-client version`` and ``reana-cluster version``.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>