### PR TITLE
cli: new CMS dimuon mass spectrum example

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,8 +12,9 @@ The list of contributors in alphabetical order:
 - `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_
 - `Leticia Wanderley <https://orcid.org/0000-0003-4649-6630>`_
 - `Lukas Heinrich <https://orcid.org/0000-0002-4048-7584>`_
-- `Robin Long <https://github.com/longr>`_
 - `Michael R. Crusoe <https://orcid.org/0000-0002-2961-9670>`_
+- `Robin Long <https://github.com/longr>`_
 - `Rokas Maciulaitis <https://orcid.org/0000-0003-1064-6967>`_
+- `Ronald Dobos <https://orcid.org/0000-0003-2914-000X>`_
 - `Sinclert Perez <https://www.linkedin.com/in/sinclert>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_

--- a/reana/cli.py
+++ b/reana/cli.py
@@ -32,6 +32,7 @@ REPO_LIST_ALL = [
     'reana-demo-alice-lego-train-test-run',
     'reana-demo-alice-pt-analysis',
     'reana-demo-bsm-search',
+    'reana-demo-cms-dimuon-mass-spectrum',
     'reana-demo-cms-h4l',
     'reana-demo-cms-reco',
     'reana-demo-lhcb-d2pimumu',


### PR DESCRIPTION
* Adds new CMS dimuon mass spectrum analysis example.
  (addresses #202)

Signed-off-by: Ronald Dobos <ronald.dobos0@gmail.com>