### PR TITLE
make: fix helm installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ ifndef HAS_MINIKUBE
 	$(error "Please install Minikube v1.0.0 or higher")
 endif
 	minikube status --profile ${MINIKUBE_PROFILE} || minikube start --profile ${MINIKUBE_PROFILE} --vm-driver ${MINIKUBE_DRIVER} --cpus ${MINIKUBE_CPUS} --memory ${MINIKUBE_MEMORY} --disk-size ${MINIKUBE_DISKSIZE} --feature-gates="TTLAfterFinished=true"
-	helm init
+	helm init --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
 	test -e ${HOME}/.virtualenvs/${VENV_NAME}/bin/activate || virtualenv ${HOME}/.virtualenvs/${VENV_NAME}
 
 clone: # Clone REANA source code repositories locally.

--- a/docs/administratorguide.rst
+++ b/docs/administratorguide.rst
@@ -193,7 +193,10 @@ script. The typical usage scenario goes as follows:
    $ # install reana-cluster utility
    $ pip install reana-cluster
    $ # deploy helm inside the Cluster
-   $ helm init
+   $ helm init --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' \
+               --output yaml | \
+               sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | \
+               kubectl create -f -
    $ # deploy new cluster and check progress
    $ reana-cluster init --traefik --generate-db-secrets
    $ reana-cluster status

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -59,7 +59,10 @@ You can also easily deploy your own REANA cloud instance by using the
    $ # install reana-cluster utility
    $ pip install reana-cluster
    $ # deploy helm inside the cluster
-   $ helm init
+   $ helm init --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' \
+               --output yaml | \
+               sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | \
+               kubectl create -f -
    $ # deploy new cluster and check progress
    $ reana-cluster init --traefik --generate-db-secrets
    $ reana-cluster status


### PR DESCRIPTION
- Helm is still creating the Tiller deployment as
  `apiVersion: extensions/v1beta1`, which has been deprecated in
  Kubernetes 1.16. See more here
  https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

  The problem has not been yet fixed in Helm upstream, once the issue
  (https://github.com/helm/helm/issues/6374) is solved we can revert
  this commit.