### PR TITLE
make: add flag to set custom server url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ help:
 	@echo '  TIMEOUT             Maximum timeout to wait when bringing cluster up and down? [default=300]'
 	@echo '  VENV_NAME           Which Python virtual environment name to use? [default=reana]'
 	@echo '  SERVER_URL          Setting a customized REANA Server hostname? [e.g. "https://myreanaserver.com"; default is Minikube IP]'
+	@echo '  CLUSTER_FLAGS       Which flags need to be passed to reana-cluster command? [e.g. "--loglevel --ui"; no flags are passed by default]'
 	@echo
 	@echo 'Examples:'
 	@echo
@@ -67,13 +68,16 @@ help:
 	@echo '  $$ minikube mount $$(pwd)/..:/code'
 	@echo '  $$ CLUSTER_CONFIG=dev make build deploy'
 	@echo
-	@echo '  # Example 4: run one small demo example to verify the build'
+	@echo '  # Example 4: build and deploy REANA with a custom hostname including REANA-UI'
+	@echo '  $$ CLUSTER_FLAGS=--ui SERVER_URL=https://reana-local.cern.ch make build deploy'
+	@echo
+	@echo '  # Example 5: run one small demo example to verify the build'
 	@echo '  $$ DEMO=reana-demo-helloworld make example'
 	@echo
-	@echo '  # Example 5: run several small examples to verify the build'
+	@echo '  # Example 6: run several small examples to verify the build'
 	@echo '  $$ make example'
 	@echo
-	@echo '  # Example 6: perform full CI build-and-test cycle'
+	@echo '  # Example 7: perform full CI build-and-test cycle'
 	@echo '  $$ make ci'
 	@echo
 	@echo '  # Example 7: perform full CI build-and-test cycle in an independent cluster'
@@ -134,7 +138,7 @@ ifeq ($(SHOULD_MINIKUBE_MOUNT),1)
 endif
 	source ${HOME}/.virtualenvs/${VENV_NAME}/bin/activate && \
 	minikube docker-env --profile ${MINIKUBE_PROFILE} > /dev/null && eval $$(minikube docker-env --profile ${MINIKUBE_PROFILE}) && \
-	reana-cluster -f ${PWD}/../reana-cluster/reana_cluster/configurations/reana-cluster-minikube$(addprefix -, ${CLUSTER_CONFIG}).yaml down && \
+	reana-cluster -f ${PWD}/../reana-cluster/reana_cluster/configurations/reana-cluster-minikube$(addprefix -, ${CLUSTER_CONFIG}).yaml $(CLUSTER_FLAGS) down && \
 	waited=0 && while true; do \
 		waited=$$(($$waited+${TIMECHECK})); \
 		if [ $$waited -gt ${TIMEOUT} ];then \
@@ -149,7 +153,7 @@ endif
 	if [ $$(docker images | grep -c '<none>') -gt 0 ]; then \
 		docker images | grep '<none>' | awk '{print $$3;}' | xargs docker rmi; \
 	fi && \
-	reana-cluster -f ${PWD}/../reana-cluster/reana_cluster/configurations/reana-cluster-minikube$(addprefix -, ${CLUSTER_CONFIG}).yaml init --traefik --generate-db-secrets && \
+	reana-cluster -f ${PWD}/../reana-cluster/reana_cluster/configurations/reana-cluster-minikube$(addprefix -, ${CLUSTER_CONFIG}).yaml $(CLUSTER_FLAGS) init --traefik --generate-db-secrets && \
 	waited=0 && while true; do \
 		waited=$$(($$waited+${TIMECHECK})); \
 		if [ $$waited -gt ${TIMEOUT} ];then \

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ help:
 	@echo '  TIMECHECK           Checking frequency in seconds when bringing cluster up and down? [default=5]'
 	@echo '  TIMEOUT             Maximum timeout to wait when bringing cluster up and down? [default=300]'
 	@echo '  VENV_NAME           Which Python virtual environment name to use? [default=reana]'
+	@echo '  SERVER_URL          Setting a customized REANA Server hostname? [e.g. "https://myreanaserver.com"; default is Minikube IP]'
 	@echo
 	@echo 'Examples:'
 	@echo
@@ -158,12 +159,13 @@ endif
 		else \
 			sleep ${TIMECHECK}; \
 		fi;\
-	done
+	done && \
+	eval $$(reana-dev setup-environment $(addprefix --server-hostname , ${SERVER_URL}))
 
 example: # Run one or several demo examples.
 	@echo -e "\033[1;32m[$$(date +%Y-%m-%dT%H:%M:%S)]\033[1;33m reana:\033[0m\033[1m make example\033[0m"
 	source ${HOME}/.virtualenvs/${VENV_NAME}/bin/activate && \
-	eval $$(reana-dev setup-environment) && \
+	eval $$(reana-dev setup-environment $(addprefix --server-hostname , ${SERVER_URL})) && \
 	reana-dev run-example -c ${DEMO}
 
 prefetch: # Prefetch interesting Docker images. Useful to speed things later.

--- a/reana/cli.py
+++ b/reana/cli.py
@@ -1391,7 +1391,10 @@ def install_cluster():  # noqa: D301
 
 
 @cli.command(name='setup-environment')
-def setup_environment():  # noqa: D301
+@click.option(
+    '--server-hostname',
+    help='Set customized REANA Server hostname.')
+def setup_environment(server_hostname):  # noqa: D301
     """Display commands to set up shell environment for local cluster.
 
     Display commands how to set up REANA_SERVER_URL and REANA_ACCESS_TOKEN
@@ -1399,9 +1402,10 @@ def setup_environment():  # noqa: D301
     passed to eval.
     """
     try:
-        print(subprocess.check_output(
-            'reana-cluster env --include-admin-token',
-            shell=True).decode().rstrip('\r\n'))
+        flag = ('--server-hostname {}'.format(server_hostname)
+                if server_hostname else '')
+        cmd = 'reana-cluster env --include-admin-token {}'.format(flag)
+        print(subprocess.check_output(cmd, shell=True).decode().rstrip('\r\n'))
     except subprocess.CalledProcessError as err:
         sys.exit(err.returncode)
 


### PR DESCRIPTION
Useful when having the GitLab integration set up i.e. the Ingress controller only accepts requests from a given host.
Usage example:
```zsh
$ SERVER_URL=https://cachopo.cern.ch DEMO=reana-demo-helloworld make example
```
Related to https://github.com/reanahub/reana-cluster/pull/241
Closes reanahub/reana-server#176