### PR TITLE
make: deployment detection improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ endif
 		waited=$$(($$waited+${TIMECHECK})); \
 		if [ $$waited -gt ${TIMEOUT} ];then \
 			break; \
-		elif [ $$(kubectl logs -l app=server -c server --tail=500 | grep -c '^Serving Flask app') -eq 1 ]; then \
+		elif [ $$(kubectl logs -l app=server -c server --tail=500 | grep -c '^Invenio database created.') -eq 1 ]; then \
 			break; \
 		else \
 			sleep ${TIMECHECK}; \


### PR DESCRIPTION
* Catch appropriate REANA-Server message when the admin account is
  created that would work for both PROD and DEV deployment scenarios.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>