### PR TITLE
make: check for Flask|uWSGI to be initialised

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ endif
 		waited=$$(($$waited+${TIMECHECK})); \
 		if [ $$waited -gt ${TIMEOUT} ];then \
 			break; \
-		elif [ $$(kubectl logs -l app=server -c server --tail=500 | grep -c '^Invenio database created.') -eq 1 ]; then \
+		elif [ $$(kubectl logs -l app=server -c server --tail=500 | grep -ce 'spawned uWSGI master process\|Serving Flask app') -eq 1 ]; then \
 			break; \
 		else \
 			sleep ${TIMECHECK}; \


### PR DESCRIPTION
* Because of reanahub/reana-server#193, where we want to silence
  start-up logs on R-Server we are losing DB events logs in prod
  like setup. Now we need should check for REANA to be ready to
  either Flask or uWSGI to be ready.