### PR TITLE
cli: www.reana.io

### DIFF
--- a/reana/cli.py
+++ b/reana/cli.py
@@ -52,7 +52,7 @@ REPO_LIST_ALL = [
     'reana-workflow-engine-serial',
     'reana-workflow-engine-yadage',
     'reana-workflow-monitor',
-    'reana.io',
+    'www.reana.io',
 ] + REPO_LIST_DEMO
 
 REPO_LIST_CLIENT = [


### PR DESCRIPTION
* Renames reana.io to www.reana.io, following up the repository name
  change on GitHub.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>