### PR TITLE
global: move cluster from reana-cluster to reana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,5 @@ target/
 .idea
 *.iml
 
-# K8S manifests
-configuration-manifests/
+# Helm Chart dependencies
+**/charts/*.tgz

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,3 +15,7 @@ recursive-include docs *.png
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include tests *.py
+recursive-include helm *.yaml
+recursive-include helm *.txt
+recursive-include helm *.helmignore
+recursive-include helm *.lock

--- a/docs/administratorguide.rst
+++ b/docs/administratorguide.rst
@@ -45,16 +45,6 @@ REANA command line client for end users.
 - known issues: `<https://github.com/reanahub/reana-client/issues>`_
 - documentation: `<https://reana-client.readthedocs.io/>`_
 
-reana-cluster
-~~~~~~~~~~~~~
-
-REANA component providing utilities to manage cluster instance.
-
-- source code: `<https://github.com/reanahub/reana-cluster>`_
-- release notes: `<https://github.com/reanahub/reana-cluster/releases>`_
-- known issues: `<https://github.com/reanahub/reana-cluster/issues>`_
-- documentation: `<https://reana-cluster.readthedocs.io/>`_
-
 reana-commons
 ~~~~~~~~~~~~~
 
@@ -182,27 +172,8 @@ The minikube can be started as follows:
 
    $ minikube start --feature-gates="TTLAfterFinished=true"
 
-REANA cluster can be easily deployed by means of the ``reana-cluster`` helper
-script. The typical usage scenario goes as follows:
+REANA cluster can be easily deployed using `Helm <https://helm.sh/>`_:
 
 .. code-block:: console
 
-   $ # create new virtual environment
-   $ virtualenv ~/.virtualenvs/myreana
-   $ source ~/.virtualenvs/myreana/bin/activate
-   $ # install reana-cluster utility
-   $ pip install reana-cluster
-   $ # deploy new cluster and check progress
-   $ reana-cluster init
-   $ reana-cluster status
-   $ # set environment variables for reana-client
-   $ eval $(reana-cluster env --include-admin-token) # since you are admin
-
-For more information, please see `REANA-Cluster's Getting started guide
-<http://reana-cluster.readthedocs.io/en/latest/gettingstarted.html>`_.
-
-Next steps
-----------
-
-For more information, you can explore `REANA-Cluster documentation
-<https://reana-cluster.readthedocs.io/>`_.
+   $ helm install reana helm/reana

--- a/docs/developerguide.rst
+++ b/docs/developerguide.rst
@@ -40,7 +40,7 @@ development mode:
 .. code-block:: console
 
    $ minikube mount $(pwd)/..:/code
-   $ CLUSTER_CONFIG=dev make build deploy
+   $ CLUSTER_FLAGS=debug.enabled=true make build deploy
 
 Let us now introduce `wdb` breakpoint as the first instruction of the
 first instruction of the `get_workflows()` function located in

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -44,29 +44,15 @@ token:
    $ export REANA_SERVER_URL=https://reana.cern.ch/
    $ export REANA_ACCESS_TOKEN=XXXXXXX
 
-You can also easily deploy your own REANA cloud instance by using the
-``reana-cluster`` command line utility (see `prerequisites
-<https://reana-cluster.readthedocs.io/en/latest/userguide.html#prerequisites>`_):
+You can also easily deploy your own REANA cloud instance by using
+`Helm <https://helm.sh/>`_:
 
 .. code-block:: console
 
    $ # install kubectl 1.16.3 and minikube 1.5.2
    $ sudo dpkg -i kubectl*.deb minikube*.deb
    $ minikube start --feature-gates="TTLAfterFinished=true"
-   $ # create new virtual environment
-   $ virtualenv ~/.virtualenvs/myreana
-   $ source ~/.virtualenvs/myreana/bin/activate
-   $ # install reana-cluster utility
-   $ pip install reana-cluster
-   $ # deploy new cluster and check progress
-   $ reana-cluster init
-   $ reana-cluster status
-   $ # set environment variables for reana-client
-   $ eval $(reana-cluster env --include-admin-token) # since you are admin
-
-See `REANA-Cluster's Getting started guide
-<http://reana-cluster.readthedocs.io/en/latest/gettingstarted.html>`_ for more
-information.
+   $ helm install reana helm/reana
 
 Step Three: Run REANA client
 ----------------------------
@@ -109,11 +95,6 @@ For more information, please see:
   utility that provides interface to both local and remote REANA cloud
   installations. For more information, please see the :ref:`userguide`. You may
   also be interested in checking out some existing :ref:`examples`.
-
-- Are you an administrator who would like to deploy and manage REANA cloud?
-  You can start by deploying REANA locally on your laptop using `reana-cluster
-  <https://reana-cluster.readthedocs.io/>`_ utility that uses Kubernetes and
-  Minikube. For more information, please see the :ref:`administratorguide`.
 
 - Are you a software developer who would like to contribute to REANA? You may be
   interested in trying out REANA both from the user point of view and the

--- a/helm/reana/.helmignore
+++ b/helm/reana/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/reana/Chart.lock
+++ b/helm/reana/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: traefik
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 1.85.0
+digest: sha256:49fc19d6bf05d412f4e4af7fa25d528cfaa1d58a476c195ee8fa2985d3dff3b9
+generated: "2020-01-06T12:57:27.524701+01:00"

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+name: reana
+description: REANA reproducible research data analysis platform
+home: www.reana.io
+icon: http://www.reana.io/static/img/logo-reana.svg
+sources:
+  - https://github.com/reanahub/reana
+  - https://github.com/reanahub/reana-client
+  - https://github.com/reanahub/reana-server
+  - https://github.com/reanahub/reana-workflow-controller
+  - https://github.com/reanahub/reana-workflow-engine-cwl
+  - https://github.com/reanahub/reana-workflow-engine-serial
+  - https://github.com/reanahub/reana-workflow-engine-yadage
+  - https://github.com/reanahub/reana-job-controller
+  - https://github.com/reanahub/reana-commons
+  - https://github.com/reanahub/reana-db
+  - https://github.com/reanahub/pytest-reana
+  - https://github.com/reanahub/www.reana.io
+keywords:
+  - research-data
+  - reproducible-analyses
+  - reproducible-workflows
+  - kubernetes
+  - containers
+  - cwl
+  - reusable-science
+type: application
+# Chart version.
+version: 0.1.0
+kubeVersion: ">= 1.13.0 <= 1.16.3"
+dependencies:
+  - name: traefik
+    version: 1.85.x
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: ingress.enabled
+    tags:
+      - ingress

--- a/helm/reana/templates/NOTES.txt
+++ b/helm/reana/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Congratulations, you've just installed REANA 🚀

--- a/helm/reana/templates/cephfs.yaml
+++ b/helm/reana/templates/cephfs.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.cephfs.enabled }}
+---
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: reana-cephfs
+  provisioner: {{ .Values.cephfs.provisioner }}
+  parameters:
+    type: {{ .Values.cephfs.type }}
+    zones: {{ .Values.cephfs.zone }}
+    osSecretName: {{ .Values.cephfs.os_necret_name }}
+    osSecretNamespace: {{ .Values.cephfs.os_necret_namespace }}
+    protocol: CEPHFS
+    backend: csi-cephfs
+    csi-driver: cephfs.csi.ceph.com
+    osShareID: {{ .Values.cephfs.cephfs_os_share_id }}
+    osShareAccessID: {{ .Values.cephfs.cephfs_os_share_access_id }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: reana-cephfs
+spec:
+  accessModes:
+  - {{ .Values.cephfs.access_modes }}
+  resources:
+    requests:
+      storage: {{ .Values.cephfs.cephfs_volume_size }}G
+  storageClassName: reana-cephfs
+{{- end }}

--- a/helm/reana/templates/ingress.yaml
+++ b/helm/reana/templates/ingress.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.ingress.enabled -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: reana-ingress
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    - http:
+        paths:
+        - path: /api
+          backend:
+            serviceName: reana-server
+            servicePort: 80
+        - path: /oauth
+          backend:
+            serviceName: reana-server
+            servicePort: 80
+        - path: /account
+          backend:
+            serviceName: reana-server
+            servicePort: 80
+        - path: /lost-password
+          backend:
+            serviceName: reana-server
+            servicePort: 80
+        - path: /confirm
+          backend:
+            serviceName: reana-server
+            servicePort: 80
+        - path: /login
+          backend:
+            serviceName: reana-server
+            servicePort: 80
+        - path: /logout
+          backend:
+            serviceName: reana-server
+            servicePort: 80
+        - path: /sign-up
+          backend:
+            serviceName: reana-server
+            servicePort: 80
+        {{- if .Values.ui.enabled }}
+        - path: /
+          backend:
+            serviceName: reana-ui
+            servicePort: 80
+        {{- end }}
+      {{- if .Values.reana_url }}
+      host: {{ .Values.reana_url }}
+      {{- end }}
+{{- end }}

--- a/helm/reana/templates/kerberos-config.yaml
+++ b/helm/reana/templates/kerberos-config.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reana-krb5-conf
+data:
+  krb5.conf: |
+        [libdefaults]
+         default_realm = CERN.CH
+         ticket_lifetime = 25h
+         renew_lifetime = 120h
+         forwardable = true
+         proxiable = true
+         default_tkt_enctypes = arcfour-hmac-md5 aes256-cts aes128-cts des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+         allow_weak_crypto = true
+         chpw_prompt = true
+         default_ccache_name = /krb5_cache/krb5_%{uid}
+
+        [realms]
+         CERN.CH = {
+          default_domain = cern.ch
+          kpasswd_server = cerndc.cern.ch
+          admin_server = cerndc.cern.ch
+          kdc = cerndc.cern.ch
+          }
+
+        [domain_realm]
+         .cern.ch = CERN.CH
+
+        pam = {
+           external = true
+           krb4_convert =  false
+           krb4_convert_524 =  false
+           krb4_use_as_req =  false
+           ticket_lifetime = 25h
+           use_shmem = sshd
+         }

--- a/helm/reana/templates/postgres.yaml
+++ b/helm/reana/templates/postgres.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reana-db
+spec:
+  type: NodePort
+  selector:
+    app: reana-db
+  ports:
+  - port: 5432
+    targetPort: 5432
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reana-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reana-db
+  template:
+    metadata:
+      labels:
+        app: reana-db
+    spec:
+      containers:
+      - name: db
+        image: postgres:9.6.2
+        ports:
+        - containerPort: 5432
+        env:
+        - name: TZ
+          value: "Europe/Zurich"
+        - name: POSTGRES_DB
+          value: reana
+        {{- if not .Values.debug.enabled }}
+        - name: POSTGRES_USER
+          value: reana
+        - name: POSTGRES_PASSWORD
+          value: reana
+        {{- else }}
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: reana-db-secrets
+              key: user
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: reana-db-secrets
+              key: password
+        {{- end }}
+        volumeMounts:
+          - name: data
+            mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          hostPath:
+            path: {{ .Values.volume_paths.db_persistence_path }}

--- a/helm/reana/templates/reana-message-broker.yaml
+++ b/helm/reana/templates/reana-message-broker.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reana-message-broker
+spec:
+  ports:
+   - port: 5672
+     targetPort: 5672
+     name: "tcp"
+     protocol: TCP
+   - port: 15672
+     targetPort: 15672
+     name: "management"
+     protocol: TCP
+  selector:
+    app: reana-message-broker
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reana-message-broker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reana-message-broker
+  template:
+    metadata:
+      labels:
+        app: reana-message-broker
+    spec:
+      containers:
+      - name: message-broker
+        image: {{ .Values.components.reana_message_broker.image }}:{{ .Values.components.reana_message_broker.tag }}
+        imagePullPolicy: {{ .Values.components.reana_message_broker.imagePullPolicy }}
+        ports:
+        - containerPort: 5672
+          name: tcp
+        - containerPort: 15672
+          name: management

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -1,0 +1,183 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reana-server
+spec:
+  type: "NodePort"
+  ports:
+  - port: 80
+    targetPort: 5000
+    name: "http"
+    protocol: TCP
+  selector:
+    app: reana-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reana-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reana-server
+  template:
+    metadata:
+      labels:
+        app: reana-server
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+      - name: rest-api
+        image: {{ .Values.components.reana_server.image }}:{{ .Values.components.reana_server.tag }}
+        imagePullPolicy: {{ .Values.components.reana_server.imagePullPolicy }}
+        ports:
+        - containerPort: 5000
+          name: http
+        {{- if .Values.debug.enabled }}
+        command: ["/bin/sh", "-c"]
+        args: ["set -e; ./scripts/setup; invenio run -h 0.0.0.0 -p 5000"]
+        tty: true
+        stdin: true
+        {{- end }}
+        volumeMounts:
+          {{- if .Values.debug.enabled }}
+          - mountPath: /code/
+            name: reana-code
+          {{- end }}
+          - mountPath: {{ .Values.volume_paths.shared_volume_path }}
+            name: reana-shared-volume
+        env:
+          {{- range $key, $value := .Values.db_env_config }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- range $key, $value := .Values.components.reana_server.environment }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- if .Values.reana_url }}
+          - name: REANA_URL
+            value: {{ .Values.reana_url }}
+          {{- end }}
+          {{- if .Values.debug.enabled }}
+          # Disable CORS in development environment, for example
+          # to connect from an external React application.
+          - name: INVENIO_CORS_SEND_WILDCARD
+            value: "False"
+          - name: INVENIO_CORS_SUPPORTS_CREDENTIALS
+            value: "True"
+          - name: WDB_SOCKET_SERVER
+            value: "reana-wdb"
+          - name: WDB_NO_BROWSER_AUTO_OPEN
+            value: "True"
+          - name: FLASK_ENV
+            value:  "development"
+          # Hack to not verify SSL connections https://stackoverflow.com/questions/48391750/disable-python-requests-ssl-validation-for-an-imported-module
+          - name: CURL_CA_BUNDLE
+            value: ""
+          - name: GIT_SSL_NO_VERIFY
+            value: "true"
+          {{- else }}
+          - name: REANA_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: reana-db-secrets
+                key: user
+          - name: REANA_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: reana-db-secrets
+                key: password
+          - name: CERN_CONSUMER_KEY
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-sso-secrets
+                key: CERN_CONSUMER_KEY
+          - name: CERN_CONSUMER_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-sso-secrets
+                key: CERN_CONSUMER_SECRET
+          - name: REANA_GITLAB_OAUTH_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-gitlab-secrets
+                key: REANA_GITLAB_OAUTH_APP_ID
+          - name: REANA_GITLAB_OAUTH_APP_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-gitlab-secrets
+                key: REANA_GITLAB_OAUTH_APP_SECRET
+          - name: REANA_GITLAB_HOST
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-gitlab-secrets
+                key: REANA_GITLAB_HOST
+          {{- end }}
+      - name: scheduler
+        image: {{ .Values.components.reana_server.image }}:{{ .Values.components.reana_server.tag }}
+        imagePullPolicy: {{ .Values.components.reana_server.imagePullPolicy }}
+        command: ["flask", "start-scheduler"]
+        volumeMounts:
+          {{- if .Values.debug.enabled }}
+          - mountPath: /code/
+            name: reana-code
+          {{- end }}
+          - mountPath: {{ .Values.volume_paths.shared_volume_path }}
+            name: reana-shared-volume
+        env:
+        {{- range $key, $value := .Values.db_env_config }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- range $key, $value := .Values.components.reana_server.environment }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- if .Values.debug.enabled }}
+        # Disable CORS in development environment, for example
+        # to connect from an external React application.
+        - name: INVENIO_CORS_SEND_WILDCARD
+          value: "False"
+        - name: INVENIO_CORS_SUPPORTS_CREDENTIALS
+          value: "True"
+        - name: WDB_SOCKET_SERVER
+          value: "reana-wdb"
+        - name: WDB_NO_BROWSER_AUTO_OPEN
+          value: "True"
+        - name: FLASK_ENV
+          value:  "development"
+        # Hack to not verify SSL connections https://stackoverflow.com/questions/48391750/disable-python-requests-ssl-validation-for-an-imported-module
+        - name: CURL_CA_BUNDLE
+          value: ""
+        - name: GIT_SSL_NO_VERIFY
+          value: "true"
+        {{- else }}
+        - name: REANA_DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: reana-db-secrets
+              key: user
+        - name: REANA_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: reana-db-secrets
+              key: password
+        {{- end }}
+      volumes:
+      - name: reana-shared-volume
+        {{- if .Values.cephfs.enabled }}
+        persistentVolumeClaim:
+          claimName: reana-cephfs
+          readOnly: false
+        {{- else }}
+        hostPath:
+          path:  {{ .Values.volume_paths.root_path }}
+        {{- end }}
+      {{- if .Values.debug.enabled }}
+      - name: reana-code
+        hostPath:
+          path: /code/reana-server
+      {{- end }}

--- a/helm/reana/templates/reana-ui.yaml
+++ b/helm/reana/templates/reana-ui.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ui.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reana-ui
+spec:
+  type: "NodePort"
+  ports:
+  - port: 80
+    targetPort: 80
+    name: "http"
+    protocol: TCP
+  selector:
+    app: reana-ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reana-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reana-ui
+  template:
+    metadata:
+      labels:
+        app: reana-ui
+    spec:
+      containers:
+      - name: ui
+        image: {{ .Values.components.reana_ui.image }}:{{ .Values.components.reana_ui.tag }}
+        imagePullPolicy: {{ .Values.components.reana_ui.imagePullPolicy }}
+        ports:
+        - containerPort: 80
+{{- end }}

--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reana-workflow-controller
+spec:
+  type: "NodePort"
+  ports:
+  - port: 80
+    targetPort: 5000
+    name: "http"
+    protocol: TCP
+  selector:
+      app: reana-workflow-controller
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reana-workflow-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reana-workflow-controller
+  template:
+    metadata:
+      labels:
+        app: reana-workflow-controller
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+      - name: rest-api
+        image: {{ .Values.components.reana_workflow_controller.image }}:{{ .Values.components.reana_workflow_controller.tag }}
+        imagePullPolicy: {{ .Values.components.reana_workflow_controller.imagePullPolicy }}
+        ports:
+        - containerPort: 5000
+          name: http
+        {{- if .Values.debug.enabled }}
+        command: ["/bin/sh","-c"]
+        args: ["flask run --host=0.0.0.0"]
+        tty: true
+        stdin: true
+        {{- end }}
+        volumeMounts:
+          {{- if .Values.debug.enabled }}
+          - mountPath: /code
+            name: reana-code
+          {{- end }}
+          - mountPath: {{ .Values.volume_paths.shared_volume_path }}
+            name: reana-shared-volume
+        env:
+          {{- range $key, $value := .Values.db_env_config }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- range $key, $value := .Values.components.reana_workflow_controller.environment }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          - name: K8S_REANA_SERVICE_ACCOUNT_NAME
+            value: {{ .Values.serviceAccount.name }}
+          - name: REANA_JOB_CONTROLLER_IMAGE
+            value: {{ .Values.components.reana_job_controller.image }}:{{ .Values.components.reana_job_controller.tag }}
+          - name: REANA_WORKFLOW_ENGINE_IMAGE_CWL
+            value: {{ .Values.components.reana_workflow_engine_cwl.image }}:{{ .Values.components.reana_workflow_engine_cwl.tag }}
+          - name: REANA_WORKFLOW_ENGINE_IMAGE_YADAGE
+            value: {{ .Values.components.reana_workflow_engine_yadage.image }}:{{ .Values.components.reana_workflow_engine_yadage.tag }}
+          - name: REANA_WORKFLOW_ENGINE_IMAGE_SERIAL
+            value: {{ .Values.components.reana_workflow_engine_serial.image }}:{{ .Values.components.reana_workflow_engine_serial.tag }}
+          {{- if .Values.reana_url }}
+          - name: REANA_URL
+            value: {{ .Values.reana_url }}
+          {{- end }}
+          {{- if .Values.eos.enabled }}
+          - name: K8S_CERN_EOS_AVAILABLE
+            value: "True"
+          {{ end }}
+          {{- if .Values.cephfs.enabled }}
+          - name: REANA_STORAGE_BACKEND
+            value: "cephfs"
+          {{ end }}
+          {{- if .Values.debug.enabled }}
+          - name: WDB_SOCKET_SERVER
+            value: "reana-wdb"
+          - name: WDB_NO_BROWSER_AUTO_OPEN
+            value: "True"
+          - name: FLASK_ENV
+            value:  "development"
+          # Hack to not verify SSL connections https://stackoverflow.com/questions/48391750/disable-python-requests-ssl-validation-for-an-imported-module
+          - name: CURL_CA_BUNDLE
+            value: ""
+          - name: GIT_SSL_NO_VERIFY
+            value: "true"
+          {{- else }}
+          - name: REANA_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: reana-db-secrets
+                key: user
+          - name: REANA_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: reana-db-secrets
+                key: password
+          - name: REANA_GITLAB_HOST
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-gitlab-secrets
+                key: REANA_GITLAB_HOST
+          {{ end }}
+      - name: job-status-consumer
+        image: {{ .Values.components.reana_workflow_controller.image }}:{{ .Values.components.reana_workflow_controller.tag }}
+        imagePullPolicy: {{ .Values.components.reana_workflow_controller.imagePullPolicy }}
+        command: ["flask", "consume-job-queue"]
+        volumeMounts:
+          {{- if .Values.debug.enabled }}
+          - mountPath: /code
+            name: reana-code
+          {{- end }}
+          - mountPath: {{ .Values.volume_paths.shared_volume_path }}
+            name: reana-shared-volume
+        env:
+        {{- range $key, $value := .Values.db_env_config }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- range $key, $value := .Values.components.reana_workflow_controller.environment }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- if .Values.reana_url }}
+        - name: REANA_URL
+          value: {{ .Values.reana_url }}
+        {{- end }}
+        {{- if .Values.debug.enabled }}
+        - name: WDB_SOCKET_SERVER
+          value: "reana-wdb"
+        - name: WDB_NO_BROWSER_AUTO_OPEN
+          value: "True"
+        - name: FLASK_ENV
+          value:  "development"
+        # Hack to not verify SSL connections https://stackoverflow.com/questions/48391750/disable-python-requests-ssl-validation-for-an-imported-module
+        - name: CURL_CA_BUNDLE
+          value: ""
+        - name: GIT_SSL_NO_VERIFY
+          value: "true"
+        {{- else }}
+        - name: REANA_DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: reana-db-secrets
+              key: user
+        - name: REANA_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: reana-db-secrets
+              key: password
+        {{ end }}
+      volumes:
+      - name: reana-shared-volume
+        {{- if .Values.cephfs.enabled }}
+        persistentVolumeClaim:
+          claimName: reana-cephfs
+          readOnly: false
+        {{- else }}
+        hostPath:
+          path: {{ .Values.volume_paths.root_path }}
+        {{- end }}
+      {{- if .Values.debug.enabled }}
+      - name: reana-code
+        hostPath:
+          path: /code/reana-workflow-controller
+      {{- end }}

--- a/helm/reana/templates/redis.yaml
+++ b/helm/reana/templates/redis.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reana-cache
+spec:
+  type: NodePort
+  selector:
+    app: reana-cache
+  ports:
+  - port: 6379
+    targetPort: 6379
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reana-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reana-cache
+  template:
+    metadata:
+      labels:
+        app: reana-cache
+    spec:
+      containers:
+      - name: cache
+        image: redis:5.0.5
+        ports:
+        - containerPort: 6379

--- a/helm/reana/templates/roles.yaml
+++ b/helm/reana/templates/roles.yaml
@@ -1,0 +1,33 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: reana-deployment-manager
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["nodes", "nodes/status", "pods", "pods/log", "secrets", "persistentvolumeclaims", "configmaps"]
+  verbs: ["get", "list", "create", "update"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["*"]
+- apiGroups: ["batch", "extensions"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Interactive web notebooks permissions
+- apiGroups: ["", "extensions", "apps", "networking.k8s.io"]
+  resources: ["deployments", "services", "ingresses"]
+  verbs: ["get", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: reana-manage-deployments
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: reana-deployment-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: default

--- a/helm/reana/templates/secrets.yaml
+++ b/helm/reana/templates/secrets.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: reana-db-secrets
+type: Opaque
+data:
+  user: {{ .Values.secrets.database.user | default "reana" | b64enc }}
+  password: {{ .Values.secrets.database.password | default "reana" | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: reana-cern-sso-secrets
+type: Opaque
+data:
+  CERN_CONSUMER_KEY: {{ .Values.secrets.cern.sso.CERN_CONSUMER_KEY | default "cern_consumer_key" | b64enc }}
+  CERN_CONSUMER_SECRET: {{ .Values.secrets.cern.sso.CERN_CONSUMER_SECRET | default "cern_consumer_secret" | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: reana-cern-gitlab-secrets
+type: Opaque
+data:
+  REANA_GITLAB_OAUTH_APP_ID: {{ .Values.secrets.cern.sso.REANA_GITLAB_OAUTH_APP_ID | default "reana_gitlab_oauth_app_id" | b64enc }}
+  REANA_GITLAB_OAUTH_APP_SECRET: {{ .Values.secrets.cern.sso.REANA_GITLAB_OAUTH_APP_SECRET | default "reana_gitlab_oauth_app_secret" | b64enc }}
+  REANA_GITLAB_HOST: {{ .Values.secrets.cern.sso.REANA_GITLAB_HOST | default "gitlab.cern.ch" | b64enc }}

--- a/helm/reana/templates/serviceaccount.yaml
+++ b/helm/reana/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Values.serviceAccount.namespace }}

--- a/helm/reana/templates/wdb.yaml
+++ b/helm/reana/templates/wdb.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.debug.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reana-wdb
+spec:
+  type: "NodePort"
+  ports:
+  - port: 19840
+    targetPort: 19840
+    name: "socket"
+    protocol: TCP
+  - port: 1984
+    targetPort: 1984
+    nodePort: 31984
+    name: "ui"
+    protocol: TCP
+  selector:
+    app: reana-wdb
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reana-wdb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reana-wdb
+  template:
+    metadata:
+      labels:
+        app: reana-wdb
+    spec:
+      containers:
+      - name: wdb
+        image: kozea/wdb:3.2.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 1984
+        - containerPort: 19840
+{{- end }}

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -1,0 +1,121 @@
+# Default values for reana.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# reana_url: reana.cern.ch
+# `reana_url` should be set for third party integrations to work and for
+# production deployments to be secure.
+
+debug:
+  enabled: false
+ui:
+  enabled: false
+eos:
+  enabled: false
+# CERN specific for now
+cephfs:
+  enabled: false
+  cephfs_volume_size: 200
+  access_modes: ReadWriteMany
+  provisioner: manila-provisioner
+  type: "Geneva CephFS Testing"
+  os_necret_name: os-trustee
+  os_necret_namespace: kube-system
+  cephfs_os_share_id: <cephfs-share-id>
+  cephfs_os_share_access_id: <cephfs-share-access-id>
+secrets:
+  database:
+    user: reana
+    # pasword: <my-db-pass>
+  gitlab:
+    REANA_GITLAB_OAUTH_APP_ID: reana
+    # REANA_GITLAB_OAUTH_APP_SECRET: <gitlab_oauth_app_secret>
+    REANA_GITLAB_HOST: gitlab.cern.ch
+  cern:
+    sso:
+      CERN_CONSUMER_KEY: reana
+      # CERN_CONSUMER_SECRET: <cern_consumer_secret>
+
+# External database service configuration
+db_env_config:
+  REANA_DB_NAME: "reana"
+  REANA_DB_HOST: "reana-db"
+  REANA_DB_PORT: "5432"
+  # There are two more environment variables that should be set in order
+  # to connect to a database:
+  # REANA_DB_USERNAME: containing the database user name.
+  # REANA_DB_PASSWORD: containing the password for the user previously set.
+  # Both environment variables should be set inside a Kubernetes secret:
+  # `reana-db-secrets`
+
+# Filesystem related configuration variables
+volume_paths:
+  root_path: "/var/reana"
+  shared_volume_path: "/var/reana"
+  db_persistence_path: "/var/reana/db"
+
+# REANA components configuration
+components:
+  reana_server:
+    imagePullPolicy: IfNotPresent
+    image: reanahub/reana-server
+    tag: latest
+    environment: []
+  reana_workflow_controller:
+    imagePullPolicy: IfNotPresent
+    image: reanahub/reana-workflow-controller
+    tag: latest
+    environment:
+      SHARED_VOLUME_PATH: /var/reana
+  reana_workflow_engine_cwl:
+    image: reanahub/reana-workflow-engine-cwl
+    tag: latest
+  reana_workflow_engine_yadage:
+    image: reanahub/reana-workflow-engine-yadage
+    tag: latest
+  reana_workflow_engine_serial:
+    image: reanahub/reana-workflow-engine-serial
+    tag: latest
+  reana_job_controller:
+    image: reanahub/reana-job-controller
+    tag: latest
+  reana_message_broker:
+    imagePullPolicy: IfNotPresent
+    image: reanahub/reana-message-broker
+    tag: latest
+  reana_ui:
+    imagePullPolicy: IfNotPresent
+    image: reanahub/reana-ui
+    tag: latest
+
+# Accessing the cluster from outside world
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.frontend.entryPoints: "http,https"
+
+# Permissions
+serviceAccount:
+  create: true
+  name: reana
+  namespace: default
+
+# Traefik's chart values.yaml
+traefik:
+  rbac:
+    enabled: true
+  dashboard:
+    enabled: true
+  kubernetes:
+    namespaces:
+      - default
+      - kube-system
+  serviceType: NodePort
+  service:
+    nodePorts:
+      http: 30080
+      https: 30443
+  ssl:
+    enabled: true
+    generateTLS: true

--- a/reana/k8s_utils.py
+++ b/reana/k8s_utils.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2020 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""REANA Kubernetes cluster utils."""
+
+import json
+import subprocess
+
+
+def exec_into_component(component_name, command):
+    """Execute a command inside a component.
+
+    :param component_name: Name of the component where the command will be
+        executed.
+    :param command: String which represents the command to execute inside
+        the component.
+    :return: Returns a string which represents the output of the command.
+    """
+    component_pod_name = subprocess.check_output([
+        'kubectl', 'get', 'pods',
+        '-l=app={component_name}'.format(component_name=component_name),
+        '-o', 'jsonpath="{.items[0].metadata.name}"'
+    ]).decode('UTF-8').replace('"', '')
+
+    component_shell = [
+        'kubectl', 'exec', '-t', component_pod_name, '--']
+
+    command_inside_component = []
+    command_inside_component.extend(component_shell)
+    command_inside_component.extend(command)
+
+    output = subprocess.check_output(command_inside_component)
+    return output.decode('UTF-8')
+
+
+def get_external_url(insecure=False):
+    """Get external IP and port to access REANA API.
+
+    :param insecure: Whether the URL should be insecure (http) or secure
+        (https).
+    :return: Returns a string which represents the full URL to access REANA.
+    """
+    minikube_ip = subprocess.check_output(
+        ['minikube', 'ip']).strip().decode('UTF-8')
+    # get service ports
+    external_ips, external_ports = get_service_ips_and_ports('reana-traefik')
+    if not external_ports:
+        external_ips, external_ports = \
+            get_service_ips_and_ports('reana-server')
+    if external_ports.get('https') and not insecure:
+        scheme = 'https'
+    else:
+        scheme = 'http'
+    return '{scheme}://{host}:{port}'.format(
+        scheme=scheme, host=minikube_ip or external_ips[0],
+        port=external_ports.get(scheme))
+
+
+def get_service_ips_and_ports(component_name):
+    """Get external IPs and ports for a given component service.
+
+    :param componenet_name: Which REANA component to fetch externals IPs and
+        ports from.
+    :return: Returns a tuple, being the first element the list of external IPs
+        and the second element the available ports.
+    """
+    try:
+        get_service_cmd = ['kubectl', 'get', 'service',
+                           component_name, '-o', 'json']
+        service_spec = subprocess.check_output(
+            get_service_cmd).strip().decode('UTF-8')
+        spec = json.loads(service_spec)
+        external_ips = spec['spec'].get('externalIPs', [])
+        ports_spec = spec['spec']['ports']
+        ports = {}
+        for port in ports_spec:
+            ports[port["name"]] = port.get("nodePort", port.get("port"))
+        return external_ips, ports
+    except subprocess.CalledProcessError:
+        return ()


### PR DESCRIPTION
* Creates a new directory with the REANA Helm chart, helm/reana-stable
  (closes #28):

  ```
  $ helm install reana helm/reana
  ```

* Secrets stop being requested interactively, if not provided they will
  be filled with default hardcoded values.

* Adds Traefik as a managed dependency, paves the way to do similar
  with Postgres, Redis and RabbitMQ.

* Prefixes all REANA components with `reana-`.