### PR TITLE
make: stop deleting modules folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ build: # Build REANA client and cluster components.
 	pip check && \
 	reana-dev git-submodule --update && \
 	reana-dev docker-build -b DEBUG=${DEBUG} && \
-	reana-dev git-submodule --delete && \
 	if [ "${DEBUG}" -gt 0 ]; then \
 		echo "Please run minikube mount in a new terminal to have live code updates." && \
 		echo "" && \


### PR DESCRIPTION
closes #236

**Note:** When working on `reana-[commons|db]` component make sure to run `reana-dev git-submodule --update` after making some changes as a way to live reload, this way the affected component will get the changes on `modules/`. Thus rebuilding the image is not needed anymore.