### PR TITLE
helm: cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,11 @@ before_install:
 
 install:
   - travis_retry pip install -e .[all]
+  - mkdir bin
+  - wget https://get.helm.sh/helm-v3.0.2-linux-amd64.tar.gz -O helm.tar.gz
+  - tar -xzf helm.tar.gz -C $PWD/bin --strip-components=1
+  - chmod +x $PWD/bin/helm
+  - export PATH=$PWD/bin:$PATH
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ help:
 	@echo '  $$ CLUSTER_FLAGS=debug.enabled=true make build deploy'
 	@echo
 	@echo '  # Example 4: build and deploy REANA with a custom hostname including REANA-UI'
-	@echo '  $$ CLUSTER_FLAGS=ui.enabled=true SERVER_URL=https://reana-local.cern.ch make build deploy'
+	@echo '  $$ CLUSTER_FLAGS=ui.enabled=true SERVER_URL=https://example.org make build deploy'
 	@echo
 	@echo '  # Example 5: run one small demo example to verify the build'
 	@echo '  $$ DEMO=reana-demo-helloworld make example'
@@ -134,7 +134,7 @@ ifeq ($(SHOULD_MINIKUBE_MOUNT),1)
 endif
 	source ${HOME}/.virtualenvs/${VENV_NAME}/bin/activate && \
 	minikube docker-env --profile ${MINIKUBE_PROFILE} > /dev/null && eval $$(minikube docker-env --profile ${MINIKUBE_PROFILE}) && \
-	helm dep update helm/reana && helm uninstall reana || \
+	helm dep update helm/reana && helm ls | grep -q reana && helm uninstall reana || \
 	waited=0 && while true; do \
 		waited=$$(($$waited+${TIMECHECK})); \
 		if [ $$waited -gt ${TIMEOUT} ];then \
@@ -198,5 +198,6 @@ test: # Run unit tests on the REANA package.
 	sphinx-build -qnNW docs docs/_build/html
 	python setup.py test
 	sphinx-build -qnNW -b doctest docs docs/_build/doctest
+	helm lint helm/reana
 
 # end of file

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -26,7 +26,7 @@ keywords:
   - reusable-science
 type: application
 # Chart version.
-version: 0.1.0
+version: 0.0.0
 kubeVersion: ">= 1.13.0 <= 1.16.3"
 dependencies:
   - name: traefik

--- a/helm/reana/templates/NOTES.txt
+++ b/helm/reana/templates/NOTES.txt
@@ -1,1 +1,1 @@
-Congratulations, you've just installed REANA 🚀
+Thanks for flying REANA 🚀

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -61,6 +61,31 @@ spec:
           - name: REANA_URL
             value: {{ .Values.reana_url }}
           {{- end }}
+          - name: CERN_CONSUMER_KEY
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-sso-secrets
+                key: CERN_CONSUMER_KEY
+          - name: CERN_CONSUMER_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-sso-secrets
+                key: CERN_CONSUMER_SECRET
+          - name: REANA_GITLAB_OAUTH_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-gitlab-secrets
+                key: REANA_GITLAB_OAUTH_APP_ID
+          - name: REANA_GITLAB_OAUTH_APP_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-gitlab-secrets
+                key: REANA_GITLAB_OAUTH_APP_SECRET
+          - name: REANA_GITLAB_HOST
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-gitlab-secrets
+                key: REANA_GITLAB_HOST
           {{- if .Values.debug.enabled }}
           # Disable CORS in development environment, for example
           # to connect from an external React application.
@@ -90,31 +115,6 @@ spec:
               secretKeyRef:
                 name: reana-db-secrets
                 key: password
-          - name: CERN_CONSUMER_KEY
-            valueFrom:
-              secretKeyRef:
-                name: reana-cern-sso-secrets
-                key: CERN_CONSUMER_KEY
-          - name: CERN_CONSUMER_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: reana-cern-sso-secrets
-                key: CERN_CONSUMER_SECRET
-          - name: REANA_GITLAB_OAUTH_APP_ID
-            valueFrom:
-              secretKeyRef:
-                name: reana-cern-gitlab-secrets
-                key: REANA_GITLAB_OAUTH_APP_ID
-          - name: REANA_GITLAB_OAUTH_APP_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: reana-cern-gitlab-secrets
-                key: REANA_GITLAB_OAUTH_APP_SECRET
-          - name: REANA_GITLAB_HOST
-            valueFrom:
-              secretKeyRef:
-                name: reana-cern-gitlab-secrets
-                key: REANA_GITLAB_HOST
           {{- end }}
       - name: scheduler
         image: {{ .Values.components.reana_server.image }}:{{ .Values.components.reana_server.tag }}

--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -79,6 +79,11 @@ spec:
           - name: REANA_STORAGE_BACKEND
             value: "cephfs"
           {{ end }}
+          - name: REANA_GITLAB_HOST
+            valueFrom:
+              secretKeyRef:
+                name: reana-cern-gitlab-secrets
+                key: REANA_GITLAB_HOST
           {{- if .Values.debug.enabled }}
           - name: WDB_SOCKET_SERVER
             value: "reana-wdb"
@@ -102,11 +107,6 @@ spec:
               secretKeyRef:
                 name: reana-db-secrets
                 key: password
-          - name: REANA_GITLAB_HOST
-            valueFrom:
-              secretKeyRef:
-                name: reana-cern-gitlab-secrets
-                key: REANA_GITLAB_HOST
           {{ end }}
       - name: job-status-consumer
         image: {{ .Values.components.reana_workflow_controller.image }}:{{ .Values.components.reana_workflow_controller.tag }}
@@ -144,6 +144,11 @@ spec:
           value: ""
         - name: GIT_SSL_NO_VERIFY
           value: "true"
+        - name: REANA_GITLAB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: reana-cern-gitlab-secrets
+              key: REANA_GITLAB_HOST
         {{- else }}
         - name: REANA_DB_USERNAME
           valueFrom:

--- a/helm/reana/templates/secrets.yaml
+++ b/helm/reana/templates/secrets.yaml
@@ -23,6 +23,6 @@ metadata:
     name: reana-cern-gitlab-secrets
 type: Opaque
 data:
-  REANA_GITLAB_OAUTH_APP_ID: {{ .Values.secrets.cern.sso.REANA_GITLAB_OAUTH_APP_ID | default "reana_gitlab_oauth_app_id" | b64enc }}
-  REANA_GITLAB_OAUTH_APP_SECRET: {{ .Values.secrets.cern.sso.REANA_GITLAB_OAUTH_APP_SECRET | default "reana_gitlab_oauth_app_secret" | b64enc }}
-  REANA_GITLAB_HOST: {{ .Values.secrets.cern.sso.REANA_GITLAB_HOST | default "gitlab.cern.ch" | b64enc }}
+  REANA_GITLAB_OAUTH_APP_ID: {{ .Values.secrets.gitlab.REANA_GITLAB_OAUTH_APP_ID | default "reana_gitlab_oauth_app_id" | b64enc }}
+  REANA_GITLAB_OAUTH_APP_SECRET: {{ .Values.secrets.gitlab.REANA_GITLAB_OAUTH_APP_SECRET | default "reana_gitlab_oauth_app_secret" | b64enc }}
+  REANA_GITLAB_HOST: {{ .Values.secrets.gitlab.REANA_GITLAB_HOST | default "gitlab.cern.ch" | b64enc }}

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -28,13 +28,13 @@ secrets:
     user: reana
     # pasword: <my-db-pass>
   gitlab:
-    REANA_GITLAB_OAUTH_APP_ID: reana
-    # REANA_GITLAB_OAUTH_APP_SECRET: <gitlab_oauth_app_secret>
-    REANA_GITLAB_HOST: gitlab.cern.ch
+    REANA_GITLAB_OAUTH_APP_ID: <CHANGEME>
+    REANA_GITLAB_OAUTH_APP_SECRET: <CHANGEME>
+    REANA_GITLAB_HOST: <CHANGEME>
   cern:
     sso:
-      CERN_CONSUMER_KEY: reana
-      # CERN_CONSUMER_SECRET: <cern_consumer_secret>
+      CERN_CONSUMER_KEY: <CHANGEME>
+      CERN_CONSUMER_SECRET: <CHANGEME>
 
 # External database service configuration
 db_env_config:

--- a/reana/cli.py
+++ b/reana/cli.py
@@ -238,7 +238,7 @@ def cli():  # noqa: D301
         $ reana-dev install-client
         $ reana-dev install-cluster
         $ reana-dev docker-build
-        $ helm delete reana
+        $ helm delete helm/reana
         $ minikube ssh 'sudo rm -rf /var/reana'
         $ helm install reana helm/reana
         $ eval $(reana-dev setup-environment)


### PR DESCRIPTION
* Use `reana-dev` as Chart name since it is a development one.

* Hides error when `reana-dev` chart is not installed and we try to
  uninstall.

* Adds environment variables from GitLab integration and CERN SSO
  on dev mode, they were missing.

* Changes installation message.