### PR TITLE
cli: run-example workflow name fix

### DIFF
--- a/reana/cli.py
+++ b/reana/cli.py
@@ -519,7 +519,7 @@ def construct_workflow_name(example, workflow_engine):
     :type example: str
     :type workflow_engine: str
     """
-    output = '{0}.{1}'.format(example.replace('reana-demo-', ''),
+    output = '{0}-{1}'.format(example.replace('reana-demo-', ''),
                               workflow_engine)
     return output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,8 +125,8 @@ def test_construct_workflow_name():
     """Tests for construct_workflow_name()."""
     from reana.cli import construct_workflow_name
     for (input_value, output_expected) in (
-            (('reana', 'cwl'), 'reana.cwl'),
-            (('reana-demo-root6-roofit', 'yadage'), 'root6-roofit.yadage'),
+            (('reana', 'cwl'), 'reana-cwl'),
+            (('reana-demo-root6-roofit', 'yadage'), 'root6-roofit-yadage'),
     ):
         output_obtained = construct_workflow_name(input_value[0],
                                                   input_value[1])


### PR DESCRIPTION
* Does not use dots in workflow names anymore as per the new restart
  workflow feature that does not allow workflow names with dots.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>