### PR TITLE
cli: verify output of logs command during CI run

### DIFF
--- a/reana/version.py
+++ b/reana/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,4 +13,4 @@ This file is imported by ``reana.__init__`` and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20191227"
+__version__ = "0.7.0.dev20200224"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019 CERN.
+# Copyright (C) 2018, 2019, 2020 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -24,16 +24,26 @@ def test_shorten_component_name():
         assert name_short == shorten_component_name(name_long)
 
 
-def test_get_default_output_for_example():
-    """Tests for get_default_output_for_example()."""
-    from reana.cli import get_default_output_for_example
+def test_get_expected_output_filenames_for_example():
+    """Tests for get_expected_output_filenames_for_example()."""
+    from reana.cli import get_expected_output_filenames_for_example
     for (example, output) in (
             ('', ('plot.png',)),
             ('reana-demo-helloworld', ('greetings.txt',)),
             ('reana-demo-root6-roofit', ('plot.png',)),
             ('reana-demo-alice-lego-train-test-run', ('plot.pdf', )),
     ):
-        assert output == get_default_output_for_example(example)
+        assert output == get_expected_output_filenames_for_example(example)
+
+
+def test_get_expected_log_message_for_example():
+    """Tests for get_expected_log_messages_for_example()."""
+    from reana.cli import get_expected_log_messages_for_example
+    for (example, output) in (
+        ('', ('job:',)),
+        ('reana-demo-helloworld', ('Parameters: inputfile=',)),
+    ):
+        assert output == get_expected_log_messages_for_example(example)
 
 
 def test_is_component_dockerised():


### PR DESCRIPTION
* Verifies presence of certain log messages that should be printed when
  running `logs` command on demo examples.  Useful to test whether the
  `logs` command returns what it should, as it happens in the past that
  the command was broken. (see reanahub/reana-job-controller#232)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>