### PR TITLE
cli: fix for `kubectl-delete-pod -c r-ui` command

### DIFF
--- a/reana/cli.py
+++ b/reana/cli.py
@@ -98,6 +98,7 @@ COMPONENT_PODS = {
     'reana-message-broker': 'reana-message-broker',
     'reana-server': 'reana-server',
     'reana-workflow-controller': 'reana-workflow-controller',
+    'reana-ui': 'reana-ui',
 }
 
 EXAMPLE_OUTPUT_FILENAMES = {


### PR DESCRIPTION
Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>