### PR TITLE
cli: new `python-unit-tests` command

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,13 @@ def test_get_expected_log_message_for_example():
         assert output == get_expected_log_messages_for_example(example)
 
 
+def test_is_component_python_package():
+    """Tests for is_component_python_package()."""
+    from reana.cli import is_component_python_package
+    assert is_component_python_package(
+        'reana') is True
+
+
 def test_is_component_dockerised():
     """Tests for is_component_dockerised()."""
     from reana.cli import is_component_dockerised


### PR DESCRIPTION
* Adds new `python-unit-tests` command that allows to launch all the
  Python unit tests for desired components using independent virtual
  environments for each REANA component. (Takes about ten minutes.)
  (closes #282)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>