### PR TITLE
helm: chart directory to reflect latest release

### DIFF
--- a/.github/workflows/helm-releaser.yaml
+++ b/.github/workflows/helm-releaser.yaml
@@ -14,8 +14,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "REANA"
-          git config user.email "reana-team@cern.ch"
+          git config user.name "REANA team"
+          git config user.email "team@reana.io"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-rc.1

--- a/.github/workflows/helm-releaser.yaml
+++ b/.github/workflows/helm-releaser.yaml
@@ -1,0 +1,25 @@
+name: Helm Chart Releaser
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Configure Git
+        run: |
+          git config user.name "REANA"
+          git config user.email "reana-team@cern.ch"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0-rc.1
+        with:
+          charts_dir: helm/reana
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ recursive-include helm *.txt
 recursive-include helm *.helmignore
 recursive-include helm *.lock
 recursive-include benchmark *.py
+recursive-include scripts *.sh
 
 # Helm
 recursive-include helm *.md

--- a/helm/configurations/values-dev.yaml
+++ b/helm/configurations/values-dev.yaml
@@ -1,0 +1,18 @@
+# REANA components pointing to `latest`, locally built master branch
+components:
+    reana_server:
+      image: reanahub/reana-server
+    reana_workflow_controller:
+      image: reanahub/reana-workflow-controller
+    reana_workflow_engine_cwl:
+      image: reanahub/reana-workflow-engine-cwl
+    reana_workflow_engine_yadage:
+      image: reanahub/reana-workflow-engine-yadage
+    reana_workflow_engine_serial:
+      image: reanahub/reana-workflow-engine-serial
+    reana_job_controller:
+      image: reanahub/reana-job-controller
+    reana_message_broker:
+      image: reanahub/reana-message-broker
+    reana_ui:
+      image: reanahub/reana-ui

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -26,7 +26,7 @@ keywords:
   - reusable-science
 type: application
 # Chart version.
-version: 0.7.0-dev20200407
+version: 0.7.0-dev20200416
 kubeVersion: ">= 1.13.0 <= 1.16.3"
 dependencies:
   - name: traefik

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -57,7 +57,7 @@ db_env_config:
 components:
   reana_server:
     imagePullPolicy: IfNotPresent
-    image: reanahub/reana-server
+    image: reanahub/reana-server:0.6.0-35-gafd0a7f
     environment:
       REANA_MAX_CONCURRENT_BATCH_WORKFLOWS: 30
     uwsgi:
@@ -65,23 +65,23 @@ components:
       threads: 4
   reana_workflow_controller:
     imagePullPolicy: IfNotPresent
-    image: reanahub/reana-workflow-controller
+    image: reanahub/reana-workflow-controller:0.6.0-36-gb702986
     environment:
       SHARED_VOLUME_PATH: /var/reana
   reana_workflow_engine_cwl:
-    image: reanahub/reana-workflow-engine-cwl
+    image: reanahub/reana-workflow-engine-cwl:0.6.0-8-g79e6bbb
   reana_workflow_engine_yadage:
-    image: reanahub/reana-workflow-engine-yadage
+    image: reanahub/reana-workflow-engine-yadage:0.6.0-13-g3df0ce0
   reana_workflow_engine_serial:
-    image: reanahub/reana-workflow-engine-serial
+    image: reanahub/reana-workflow-engine-serial:0.6.0-13-gef2eb4c
   reana_job_controller:
-    image: reanahub/reana-job-controller
+    image: reanahub/reana-job-controller:0.6.0-30-g84b8271
   reana_message_broker:
     imagePullPolicy: IfNotPresent
-    image: reanahub/reana-message-broker
+    image: reanahub/reana-message-broker:0.6.0-1-gac35315
   reana_ui:
     imagePullPolicy: IfNotPresent
-    image: reanahub/reana-ui
+    image: reanahub/reana-ui:0.6.0-48-gbe42a5d
 
 # Accessing the cluster from outside world
 ingress:

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# This file is part of REANA.
+# Copyright (C) 2020 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+SCRIPT_DIRECTORY=$(dirname "$0")
+REANA_HELM_CHART_VALUES_YAML_DIR="$SCRIPT_DIRECTORY/../helm/reana"
+VALUES_YAML_FILE_NAME='values.yaml'
+REANA_HELM_CHART_VALUES_YAML_PATH="$REANA_HELM_CHART_VALUES_YAML_DIR/$VALUES_YAML_FILE_NAME"
+
+# Parameters
+if [ "$#" -ne 1 ]; then
+  echo "Wrong number of parameters, use:"
+  echo ""
+  echo -e "\t./update-images.sh <images-txt-file>"
+  echo ""
+  echo "Examples:"
+  echo ""
+  echo "To update values.yaml with images in images.txt"
+  echo ""
+  echo -e "\t./scripts/update-images.sh v0.7.0.txt"
+  echo ""
+  exit 1
+fi
+
+images_file_path=$1
+
+if [ -f "$images_file_path" ]; then
+  for image in $(cat $images_file_path);
+  do
+    image_name=$(echo "$image" | cut -d":" -f1)
+    image_tag=$(echo "$image" | cut -d":" -f2)
+    if grep "$image_name" "$REANA_HELM_CHART_VALUES_YAML_PATH" | grep -qv "$image_tag"; then
+      echo "Updating $image_name to $image_tag."
+      sed -i -e "s|$image_name.*|$image_name:$image_tag|g" "$REANA_HELM_CHART_VALUES_YAML_PATH"
+      if [ -f "$REANA_HELM_CHART_VALUES_YAML_DIR/values.yaml-e" ]; then
+        # remove temporary files created in BSD
+        rm "$REANA_HELM_CHART_VALUES_YAML_DIR"/values.yaml-e
+      fi
+    fi
+  done
+fi


### PR DESCRIPTION
Closes https://github.com/reanahub/reana/issues/288

---

This PR includes automatic Helm Chart releases with [Helm Chart Releaser Action](https://github.com/marketplace/actions/helm-chart-releaser?version=v1.0.0-rc.2), leaving the following actions to be taken:
- [x] Set up an access token to be stored in the repository (see more [here](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets)). Probably we want this token to be a [machine user token](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users), for example `reana`. (should be done by repo owner)
- [x] Create a new branch `gh-pages` for the CR Action to work (it expects a `gh-pages` branch always) 
- [x] Remove [releasing charts docs](http://docs.reana.io/development/releasing/) as it will be automated.