### PR TITLE
helm: load uwsgi config as configmap

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,6 +21,7 @@ recursive-include helm *.yaml
 recursive-include helm *.txt
 recursive-include helm *.helmignore
 recursive-include helm *.lock
+recursive-include benchmark *.py
 
 # Helm
 recursive-include helm *.md

--- a/benchmark/locustfile.py
+++ b/benchmark/locustfile.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2020 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Locust file for a default REANA instance stress testing.
+
+Usage:
+.. code-block:: console
+  $ pip install locust
+
+.. code-block:: console
+  $ locust -f benchmark/locustfile.py --host=$REANA_SERVER_URL
+  [2020-04-14 16:31:54,321] x.home/INFO/locust.main: Starting web monitor
+  at http://*:8089
+  [2020-04-14 16:31:54,321] x.home/INFO/locust.main: Starting Locust 0.14.5
+  ...
+  $ firefox http://127.0.0.1:8089
+
+"""
+
+import os
+
+from locust import HttpLocust, TaskSet, between, task
+
+TOKEN = os.environ.get('REANA_ACCESS_TOKEN')
+
+dummy_spec = {
+    "workflow": {
+        "specification": {
+            "steps": [
+                {
+                    "environment": "reanahub/reana-env-jupyter",
+                    "commands": [
+                        "echo 'Hello REANA'"
+                    ]
+                }
+            ]
+        },
+        "type": "serial",
+    },
+}
+
+workflow_name = 'myworkflow'
+
+
+class WorkflowsTaskSet(TaskSet):
+    """Get workflows."""
+
+    def on_start(self):
+        """On start."""
+        self.client.verify = False
+
+    def setup(self):
+        """Create 10 workflows to query them."""
+        for _ in range(10):
+            self.client.post('/api/workflows',
+                             params=(('workflow_name', workflow_name),
+                                     ('access_token', TOKEN)),
+                             json=dummy_spec, verify=False)
+
+    @task
+    def ping(self):
+        """Ping reana instance."""
+        self.client.get(f'/api/ping')
+
+    @task
+    def get_worflows(self):
+        """Get workflows."""
+        self.client.get(f'/api/workflows',
+                        params=(('access_token', TOKEN),))
+
+    @task
+    def get_worflow_logs(self):
+        """Get workflow logs."""
+        self.client.get(f'/api/workflows/{workflow_name}/logs',
+                        params=(('access_token', TOKEN),))
+
+
+class WebsiteUser(HttpLocust):
+    """Locust instance. Represent the user that attacks the system."""
+
+    task_set = WorkflowsTaskSet
+    wait_time = between(5, 10)

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -40,6 +40,10 @@ spec:
         args: ["set -e; ./scripts/setup; invenio run -h 0.0.0.0 -p 5000"]
         tty: true
         stdin: true
+        {{- else }}
+        command: ["/bin/sh", "-c"]
+        args: ["./scripts/setup > /var/log/reana-server-init-output.log 2>&1 &&
+                uwsgi --ini /var/reana/uwsgi/uwsgi.ini"]
         {{- end }}
         volumeMounts:
           {{- if .Values.debug.enabled }}
@@ -48,6 +52,8 @@ spec:
           {{- end }}
           - mountPath: {{ .Values.shared_storage.shared_volume_mount_path }}
             name: reana-shared-volume
+          - name: uwsgi-config
+            mountPath: '/var/reana/uwsgi'
         env:
           - name: REANA_COMPONENT_PREFIX
             value: {{ include "reana.prefix" . }}
@@ -185,3 +191,7 @@ spec:
         hostPath:
           path: /code/reana-server
       {{- end }}
+      - name: uwsgi-config
+        configMap:
+          defaultMode: 420
+          name: uwsgi-config

--- a/helm/reana/templates/uwsgi-config.yaml
+++ b/helm/reana/templates/uwsgi-config.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uwsgi-config
+data:
+  uwsgi.ini: |
+    [uwsgi]
+    stats = /tmp/stats.socket
+    http-socket = 0.0.0.0:5000
+    module = invenio_app.wsgi:application
+    master = true
+    processes = {{ .Values.components.reana_server.uwsgi.processes }}
+    threads = {{ .Values.components.reana_server.uwsgi.threads }}
+    single-interpreter = true
+    need-app = true
+    wsgi-disable-file-wrapper = true
+
+    auto-procname = true
+    buffer-size =  10240
+    post-buffering = true
+    lazy-apps = true
+    # thunder-lock = true # https://marc.info/?l=uwsgi&m=140473636200986&w=2
+                          # https://uwsgi-docs.readthedocs.io/en/latest/articles/SerializingAccept.html
+
+    # Logging
+    disable-logging = true
+    log-4xx = true
+    log-5xx = true
+
+    # Workers management
+    max-requests = 1999
+    max-requests-delta = 149
+    # max-worker-lifetime = 3600 # https://github.com/unbit/uwsgi/issues/1894
+    reload-on-rss = 250
+
+    # fix up signal handling
+    die-on-term = true
+    hook-master-start = unix_signal:2 gracefully_kill_them_all
+    hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -60,6 +60,9 @@ components:
     image: reanahub/reana-server
     environment:
       REANA_MAX_CONCURRENT_BATCH_WORKFLOWS: 30
+    uwsgi:
+      processes: 6
+      threads: 4
   reana_workflow_controller:
     imagePullPolicy: IfNotPresent
     image: reanahub/reana-workflow-controller

--- a/reana/cli.py
+++ b/reana/cli.py
@@ -1525,16 +1525,16 @@ def setup_environment(server_hostname, insecure_url, namespace):  # noqa: D301
     try:
         export_lines = []
         component_export_line = 'export {env_var_name}={env_var_value}'
-
         export_lines.append(component_export_line.format(
             env_var_name='REANA_SERVER_URL',
-            env_var_value=server_hostname or get_external_url(insecure_url)))
+            env_var_value=server_hostname or get_external_url(insecure_url,
+                                                              namespace)))
 
         get_admin_token_sql_query_cmd = [
             'psql', '-U', 'reana', 'reana', '-c',
             'SELECT access_token FROM user_']
         sql_query_result = exec_into_component(
-            get_prefixed_component_name('db'),
+            get_prefixed_component_name('db', namespace),
             get_admin_token_sql_query_cmd)
         # We get the token from the SQL query result
         admin_access_token = sql_query_result.splitlines()[2].strip()

--- a/reana/k8s_utils.py
+++ b/reana/k8s_utils.py
@@ -40,7 +40,7 @@ def exec_into_component(component_name, command):
     return output.decode('UTF-8')
 
 
-def get_external_url(insecure=False):
+def get_external_url(insecure=False, namespace=None):
     """Get external IP and port to access REANA API.
 
     :param insecure: Whether the URL should be insecure (http) or secure
@@ -48,11 +48,11 @@ def get_external_url(insecure=False):
     :return: Returns a string which represents the full URL to access REANA.
     """
     minikube_ip = subprocess.check_output(
-        ['minikube', 'ip', '--profile', INSTANCE_NAME]
+        ['minikube', 'ip', '--profile', namespace or INSTANCE_NAME]
     ).strip().decode('UTF-8')
     # get service ports
-    traefik_name = get_prefixed_component_name('traefik')
-    server_name = get_prefixed_component_name('server')
+    traefik_name = get_prefixed_component_name('traefik', namespace)
+    server_name = get_prefixed_component_name('server', namespace)
     external_ips, external_ports = get_service_ips_and_ports(traefik_name)
     if not external_ports:
         external_ips, external_ports = \
@@ -90,11 +90,11 @@ def get_service_ips_and_ports(component_name):
         return ()
 
 
-def get_prefixed_component_name(component):
+def get_prefixed_component_name(component, namespace):
     """Get prefixed component name.
 
     :param component: String representing the component name.
 
     :return: Prefixed name.
     """
-    return '-'.join([INSTANCE_NAME, component])
+    return '-'.join([namespace or INSTANCE_NAME, component])


### PR DESCRIPTION
closes reanahub/reana-server#228

## metrics-server

Many performance tests were done using the new [`metrics-server`](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-metrics-pipeline/)

```console
$ kubectl top pod reana-server-xyx
NAME.                CPU(cores)         MEMORY(bytes)   
reana-server-xyz.    0m                 312Mi


$ kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/default/pods/reana-server-xyz  | jq
{
  "kind": "PodMetrics",
  "apiVersion": "metrics.k8s.io/v1beta1",
  "metadata": {
    "name": "reana-server-xyz",
    "namespace": "default",
    "selfLink": "/apis/metrics.k8s.io/v1beta1/namespaces/default/pods/reana-server-xtz",
    "creationTimestamp": "2020-04-13T14:58:14Z"
  },
  "timestamp": "2020-04-13T14:58:00Z",
  "window": "1m0s",
  "containers": [
    {
      "name": "rest-api",
      "usage": {
        "cpu": "0",
        "memory": "220124Ki"
      }
    },
    {
      "name": "scheduler",
      "usage": {
        "cpu": "0",
        "memory": "99628Ki"
      }
    }
  ]
}


```

Memory usage doesn't seem to skyrocket at any moment, the maximum I got was 360Mi (2 processes and 2 threads in uwsgi conf), so in that regard, it seems to be fine. Let's see some more advanced test using [locust](https://locust.io/) to determine the best value for [processes](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#processes) and [threads](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#threads).


##  locust

Conditions: 2 minutes, 500 users, hatch rate 10.

### a) 1 thread, 1 process

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/8863238/79238767-14e1ca00-7e70-11ea-9317-1a1ed06b2b1b.png">

<img width="1661" alt="image" src="https://user-images.githubusercontent.com/8863238/79238820-20cd8c00-7e70-11ea-88e7-e392445c422f.png">

<img width="1678" alt="image" src="https://user-images.githubusercontent.com/8863238/79238873-317e0200-7e70-11ea-894a-b9851bcbf540.png">

(same for all)
<img width="1659" alt="image" src="https://user-images.githubusercontent.com/8863238/79237861-f0392280-7e6e-11ea-9d15-6f993f4b82f2.png">

**Memory usage:** ~230Mi


### b) 2 threads, 2 processes

<img width="1675" alt="image" src="https://user-images.githubusercontent.com/8863238/79237728-c7189200-7e6e-11ea-93fd-67374ebe6b83.png">

<img width="1665" alt="image" src="https://user-images.githubusercontent.com/8863238/79237813-e44d6080-7e6e-11ea-882f-94a9861b398e.png">

**Memory usage:** ~360Mi


### c) 4 threads, 6 process (invenio-rdm)

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/8863238/79239643-195ab280-7e71-11ea-9354-c2c3519b4577.png">

<img width="1657" alt="image" src="https://user-images.githubusercontent.com/8863238/79239669-21b2ed80-7e71-11ea-82a5-4c294212091d.png">

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/8863238/79239723-2f687300-7e71-11ea-9a32-ed5bd6cb6179.png">

**Memory usage:** ~735Mi


## Some conclusions
- When increasing the number of processes and threads memory usage (230Mi vs 735Mi) increases but the server is much more performant (27.9 vs 61.5 requests per second).
- The number of failures is minimum for a) and c) whereas b) seems to struggle more.
- We should find a balance between memory usage and performance. If using ~700Mi of memory is not a problem we should definitely go for something similar to c).
