### PR TITLE
Changes to Helm chart and RBAC for SSL-RIVER

### DIFF
--- a/helm/my-values.yaml
+++ b/helm/my-values.yaml
@@ -1,0 +1,12 @@
+reana_url: reana.ssl-hep.org
+components:
+  reana_server:
+    image: reanahub/reana-server:0.6.0-26-g7b8f8f6
+  reana_workflow_controller:
+    image: reanahub/reana-workflow-controller:0.6.0-13-g82e18bd
+  reana_message_broker:
+    image: reanahub/reana-message-broker:0.6.0-1-gac35315
+serviceAccount:
+  namespace: reana-cluster
+traefik:
+  enabled: false

--- a/helm/reana/Chart.lock
+++ b/helm/reana/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: traefik
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.85.1
-digest: sha256:01f0d3a527044b2100518da3ed4d5079e3b6a1100171d662182c2177421d9bd7
-generated: "2020-01-16T12:23:56.628299438+01:00"
+digest: sha256:02d4c8bfed2e60d116002b48528a9bf5ab563fff7cb57251a8806e69f27b14db
+generated: "2020-03-17T13:16:07.1771152-05:00"

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
 type: application
 # Chart version.
 version: 0.0.0
-kubeVersion: ">= 1.13.0 <= 1.16.3"
+kubeVersion: ">= 1.13.0 <= 1.16.7"
 dependencies:
   - name: traefik
     version: 1.85.x

--- a/helm/reana/templates/roles.yaml
+++ b/helm/reana/templates/roles.yaml
@@ -1,33 +1,35 @@
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: default
+  namespace: reana-cluster
   name: reana-deployment-manager
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["nodes", "nodes/status", "pods", "pods/log", "secrets", "persistentvolumeclaims", "configmaps"]
-  verbs: ["get", "list", "create", "update", "watch"]
-- apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses"]
-  verbs: ["*"]
-- apiGroups: ["batch", "extensions"]
+  resources: ["pods", "secrets", "persistentvolumeclaims", "configmaps", "services"]
+  verbs: ["get", "list", "create", "update", "watch", "delete"]
+- apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-# Interactive web notebooks permissions
-- apiGroups: ["", "extensions", "apps", "networking.k8s.io"]
-  resources: ["deployments", "services", "ingresses"]
+- apiGroups: ["extensions"]
+  resources: ["deployments", "ingresses"]
+  verbs: ["get", "create", "delete"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "create", "delete"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
   verbs: ["get", "create", "delete"]
 ---
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
 metadata:
   name: reana-manage-deployments
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: reana-deployment-manager
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}
-  namespace: default
+  namespace: reana-cluster


### PR DESCRIPTION
This is a WIP pull request to get the ball rolling. The goal is to implement a Helm deployment that can work in environments where the user lacks admin access, such as SSL-RIVER. The primary changes are the addition of a my-values.yaml file to track necessary changes to the default values in reana/Chart.yaml, and significant changes to reana/templates/roles.yaml to reflect the permissions available in the RIVER cluster. If these aren't sufficient to run real examples we can iterate between the REANA devs and the RIVER admins to reach a sensible compromise.