### PR TITLE
cli: remove namespace from setup-environment

### DIFF
--- a/reana/cli.py
+++ b/reana/cli.py
@@ -1511,11 +1511,7 @@ def install_client():  # noqa: D301
 @click.option(
     '--insecure-url', is_flag=True,
     help='REANA Server URL with HTTP.')
-@click.option(
-    '--namespace',
-    default='default',
-    help='Namespace of the components which configuration should be produced.')
-def setup_environment(server_hostname, insecure_url, namespace):  # noqa: D301
+def setup_environment(server_hostname, insecure_url):  # noqa: D301
     """Display commands to set up shell environment for local cluster.
 
     Display commands how to set up REANA_SERVER_URL and REANA_ACCESS_TOKEN
@@ -1527,14 +1523,13 @@ def setup_environment(server_hostname, insecure_url, namespace):  # noqa: D301
         component_export_line = 'export {env_var_name}={env_var_value}'
         export_lines.append(component_export_line.format(
             env_var_name='REANA_SERVER_URL',
-            env_var_value=server_hostname or get_external_url(insecure_url,
-                                                              namespace)))
+            env_var_value=server_hostname or get_external_url(insecure_url)))
 
         get_admin_token_sql_query_cmd = [
             'psql', '-U', 'reana', 'reana', '-c',
             'SELECT access_token FROM user_']
         sql_query_result = exec_into_component(
-            get_prefixed_component_name('db', namespace),
+            get_prefixed_component_name('db'),
             get_admin_token_sql_query_cmd)
         # We get the token from the SQL query result
         admin_access_token = sql_query_result.splitlines()[2].strip()

--- a/reana/k8s_utils.py
+++ b/reana/k8s_utils.py
@@ -40,7 +40,7 @@ def exec_into_component(component_name, command):
     return output.decode('UTF-8')
 
 
-def get_external_url(insecure=False, namespace=None):
+def get_external_url(insecure=False):
     """Get external IP and port to access REANA API.
 
     :param insecure: Whether the URL should be insecure (http) or secure
@@ -48,11 +48,11 @@ def get_external_url(insecure=False, namespace=None):
     :return: Returns a string which represents the full URL to access REANA.
     """
     minikube_ip = subprocess.check_output(
-        ['minikube', 'ip', '--profile', namespace or INSTANCE_NAME]
+        ['minikube', 'ip', '--profile', INSTANCE_NAME]
     ).strip().decode('UTF-8')
     # get service ports
-    traefik_name = get_prefixed_component_name('traefik', namespace)
-    server_name = get_prefixed_component_name('server', namespace)
+    traefik_name = get_prefixed_component_name('traefik')
+    server_name = get_prefixed_component_name('server')
     external_ips, external_ports = get_service_ips_and_ports(traefik_name)
     if not external_ports:
         external_ips, external_ports = \
@@ -90,11 +90,11 @@ def get_service_ips_and_ports(component_name):
         return ()
 
 
-def get_prefixed_component_name(component, namespace):
+def get_prefixed_component_name(component):
     """Get prefixed component name.
 
     :param component: String representing the component name.
 
     :return: Prefixed name.
     """
-    return '-'.join([namespace or INSTANCE_NAME, component])
+    return '-'.join([INSTANCE_NAME, component])

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'pytest-reana==0.7.0.dev20191219',
+    'pytest-reana>=0.7.0.dev20200417',
 ]
 
 extras_require = {


### PR DESCRIPTION
* This allows to setup-environment for multiple local REANA
  instances and fixes the problem of always using `default` as
  instance name (#292).