### PR TITLE
make: fix spacing typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ deploy: # Deploy/redeploy previously built REANA cluster.
 	if [ $$(docker images | grep -c '<none>') -gt 0 ]; then \
 		docker images | grep '<none>' | awk '{print $$3;}' | xargs docker rmi; \
 	fi && \
-	helm install ${TRUNC_INSTANCE_NAME} helm/reana $(addprefix --set , ${CLUSTER_FLAGS}) $(addprefix -f, ${VALUES_YAML_PATH}) --wait && \
+	helm install ${TRUNC_INSTANCE_NAME} helm/reana $(addprefix --set , ${CLUSTER_FLAGS}) $(addprefix -f , ${VALUES_YAML_PATH}) --wait && \
 	waited=0 && while true; do \
 		waited=$$(($$waited+${TIMECHECK})); \
 		if [ $$waited -gt ${TIMEOUT} ];then \


### PR DESCRIPTION
It was resulting in e.g. `helm install reana helm/reana  -fhelm/configurations/values-dev.yaml --wait`. Notice the lack of space between `-f` and its value.