### PR TITLE
helm: add reana secret key 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - python: 2.7
     - python: 3.6
     - python: 3.7
     - python: 3.8

--- a/helm/reana/README.md
+++ b/helm/reana/README.md
@@ -40,6 +40,7 @@ This Helm automatically prefixes all names using the release name to avoid colli
 | `secrets.gitlab.REANA_GITLAB_HOST`                       | Hostname of the GitLab instance                                                      | None                                            |
 | `secrets.gitlab.REANA_GITLAB_OAUTH_APP_ID`               | GitLab OAuth application id                                                          | None                                            |
 | `secrets.gitlab.REANA_GITLAB_OAUTH_APP_SECRET`           | **[Do not use in production, use secrets instead]** GitLab OAuth application secret  | None                                            |
+| `secrets.reana.REANA_SECRET_KEY`                         | **[Do not use in production, use secrets instead]** REANA encrypytion secret key     | None                                            |
 | `serviceAccount.create`                                  | Create a service account for the REANA system user                                   | true                                            |
 | `serviceAccount.name`                                    | Service account name                                                                 | reana                                           |
 | `serviceAccount.namespace`                               | Service account namespace                                                            | default                                         |

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -93,6 +93,11 @@ spec:
               secretKeyRef:
                 name: {{ include "reana.prefix" . }}-cern-gitlab-secrets
                 key: REANA_GITLAB_HOST
+          - name: REANA_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "reana.prefix" . }}-secrets
+                key: REANA_SECRET_KEY
           {{- if .Values.debug.enabled }}
           # Disable CORS in development environment, for example
           # to connect from an external React application.

--- a/helm/reana/templates/secrets.yaml
+++ b/helm/reana/templates/secrets.yaml
@@ -32,3 +32,13 @@ data:
   REANA_GITLAB_OAUTH_APP_ID: {{ .Values.secrets.gitlab.REANA_GITLAB_OAUTH_APP_ID | default "reana_gitlab_oauth_app_id" | b64enc }}
   REANA_GITLAB_OAUTH_APP_SECRET: {{ .Values.secrets.gitlab.REANA_GITLAB_OAUTH_APP_SECRET | default "reana_gitlab_oauth_app_secret" | b64enc }}
   REANA_GITLAB_HOST: {{ .Values.secrets.gitlab.REANA_GITLAB_HOST | default "gitlab.cern.ch" | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "reana.prefix" . }}-secrets
+  annotations:
+    "helm.sh/resource-policy": keep
+type: Opaque
+data:
+  REANA_SECRET_KEY: {{ .Values.secrets.reana.REANA_SECRET_KEY | default "secret_key" | b64enc }}

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -32,6 +32,7 @@ secrets:
   gitlab: {}
   cern:
     sso: {}
+  reana: {}
 
 # External database service configuration
 db_env_config:

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
closes reanahub/reana-db#66

⚠️ The [`reana-dev setup-environment` problem](https://github.com/reanahub/reana/blob/master/reana/cli.py#L1528-L1530) (encrypted token output) still need to be addressed or ticketized.