### PR TITLE
helm: trigger cr action on change Chart.yaml

### DIFF
--- a/.github/workflows/helm-releaser.yaml
+++ b/.github/workflows/helm-releaser.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - 'helm/reana/**'
+      - 'helm/reana/Chart.yaml'
 
 jobs:
   release:


### PR DESCRIPTION
So we can control helm chart releaser github action workflows better and avoid extra runs.