### PR TITLE
helm: add reana secret key env var

### DIFF
--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -26,7 +26,7 @@ keywords:
   - reusable-science
 type: application
 # Chart version.
-version: 0.7.0-dev20200529
+version: 0.7.0-dev20200602
 kubeVersion: ">= 1.13.0 <= 1.18"
 dependencies:
   - name: traefik

--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -90,6 +90,11 @@ spec:
               secretKeyRef:
                 name: {{ include "reana.prefix" . }}-cern-gitlab-secrets
                 key: REANA_GITLAB_HOST
+          - name: REANA_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "reana.prefix" . }}-secrets
+                key: REANA_SECRET_KEY
           {{- if .Values.debug.enabled }}
           - name: WDB_SOCKET_SERVER
             value: "{{ include "reana.prefix" . }}-wdb"


### PR DESCRIPTION
Fixes interactive sessions as workflow-controller calls
[`get_owner_access_token()`](https://github.com/reanahub/reana-workflow-controller/blob/master/reana_workflow_controller/workflow_run_manager.py#L258) that needs the `SECRET_KEY` to get the
access_token.

closes #325