### PR TITLE
helm: add announcement configmap

### DIFF
--- a/helm/reana/templates/announcement-config.yaml
+++ b/helm/reana/templates/announcement-config.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: announcement-config
+data:
+  announcement: ""

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -98,6 +98,11 @@ spec:
               secretKeyRef:
                 name: {{ include "reana.prefix" . }}-secrets
                 key: REANA_SECRET_KEY
+          - name: REANA_UI_ANNOUNCEMENT
+            valueFrom:
+              configMapKeyRef:
+                name: announcement-config
+                key: announcement
           {{- if .Values.debug.enabled }}
           # Disable CORS in development environment, for example
           # to connect from an external React application.


### PR DESCRIPTION
closes reanahub/reana-ui#83

How to update the announcement:
```console
$ kubectl edit configmaps announcement-config
# edit `announcement` key
$ kubectl delete pod reana-server-xxx-yyy