### PR TITLE
config: use centrally configured k8s namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 install:
   - travis_retry pip install -e .[all]
   - mkdir bin
-  - wget https://get.helm.sh/helm-v3.0.2-linux-amd64.tar.gz -O helm.tar.gz
+  - wget https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz -O helm.tar.gz
   - tar -xzf helm.tar.gz -C $PWD/bin --strip-components=1
   - chmod +x $PWD/bin/helm
   - export PATH=$PWD/bin:$PATH

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version master (UNRELEASED)
 ---------------------------
 
+- Adds possibility to install REANA in different namespaces than default.
 - Moves to Helm deployment.
 - Adds command to bump common packages versions.
 - Supports prefixing by Helm release name.

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,8 @@ deploy: # Deploy/redeploy previously built REANA cluster.
 	if [ $$(docker images | grep -c '<none>') -gt 0 ]; then \
 		docker images | grep '<none>' | awk '{print $$3;}' | xargs docker rmi; \
 	fi && \
-	helm install ${TRUNC_INSTANCE_NAME} helm/reana $(addprefix --set , ${CLUSTER_FLAGS}) $(addprefix -f , ${VALUES_YAML_PATH}) --wait && \
+	helm install ${TRUNC_INSTANCE_NAME} helm/reana $(addprefix --set , ${CLUSTER_FLAGS}) $(addprefix -f , ${VALUES_YAML_PATH}) --wait --namespace ${INSTANCE_NAME} --create-namespace && \
+	kubectl config set-context --current --namespace=${INSTANCE_NAME} && \
 	waited=0 && while true; do \
 		waited=$$(($$waited+${TIMECHECK})); \
 		if [ $$waited -gt ${TIMEOUT} ];then \

--- a/helm/reana/README.md
+++ b/helm/reana/README.md
@@ -41,6 +41,8 @@ This Helm automatically prefixes all names using the release name to avoid colli
 | `notifications.email_config.smtp_port`                   | SMTP email server port                                                               | None                                            |
 | `notifications.enabled`                                  | Enable REANA system events notifications                                             | false                                           |
 | `notifications.system_status`                            | Cronjob pattern representing how often the system status notification should be sent. Leave it empty to deactivate it | "0 0 * * *"                                     |
+| `reana_url`                                              | REANA URL host                                                                       | None                                            |
+| `default_runtime_namespace`                              | Namespace in which the REANA runtime pods (workflow engines, jobs etc...) will run   | None                                            |
 | `secrets.cern.sso.CERN_CONSUMER_KEY`                     | CERN SSO consumer key                                                                | None                                            |
 | `secrets.cern.sso.CERN_CONSUMER_SECRET`                  | **[Do not use in production, use secrets instead]** CERN SSO consumer secret         | None                                            |
 | `secrets.database.pasword`                               | **[Do not use in production, use secrets instead]** PostgreSQL database password     | None                                            |

--- a/helm/reana/README.md
+++ b/helm/reana/README.md
@@ -51,7 +51,6 @@ This Helm automatically prefixes all names using the release name to avoid colli
 | `secrets.reana.REANA_SECRET_KEY`                         | **[Do not use in production, use secrets instead]** REANA encryption secret key     | None                                            |
 | `serviceAccount.create`                                  | Create a service account for the REANA system user                                   | true                                            |
 | `serviceAccount.name`                                    | Service account name                                                                 | reana                                           |
-| `serviceAccount.namespace`                               | Service account namespace                                                            | default                                         |
 | `shared_storage.access_modes`                            | Shared volume access mode                                                            | ReadWriteMany                                   |
 | `shared_storage.backend`                                 | Shared volume storage backend                                                        | hostpath                                        |
 | `shared_storage.cephfs.availability_zone`                | **[CERN only]** OpenStack Availability zone                                          | nova                                            |

--- a/helm/reana/templates/_helpers.tpl
+++ b/helm/reana/templates/_helpers.tpl
@@ -20,7 +20,10 @@ naming spec: `my-reana-batch-yadage-3c640169-d3b7-41ad-9c09-392c903fc1d8`
 {{- end -}}
 {{- end -}}
 
-# Centralise prefixing of
-{{- define "reana.prefixed_svaccount_name" -}}
-{{- include "reana.prefix" . -}}-{{- .Values.serviceAccount.name -}}
+# Centralise prefixing of service account names
+{{- define "reana.prefixed_infrastructure_svaccount_name" -}}
+{{- include "reana.prefix" . -}}-infrastructure
+{{- end -}}
+{{- define "reana.prefixed_runtime_svaccount_name" -}}
+{{- include "reana.prefix" . -}}-runtime
 {{- end -}}

--- a/helm/reana/templates/announcement-config.yaml
+++ b/helm/reana/templates/announcement-config.yaml
@@ -3,5 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: announcement-config
+  namespace: {{ .Release.Namespace }}
 data:
   announcement: ""

--- a/helm/reana/templates/cronjobs.yaml
+++ b/helm/reana/templates/cronjobs.yaml
@@ -4,6 +4,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ include "reana.prefix" . }}-system-status
+  namespace: {{ .Release.Namespace }}
 spec:
   schedule: "{{ .Values.notifications.system_status }}"
   jobTemplate:

--- a/helm/reana/templates/cronjobs.yaml
+++ b/helm/reana/templates/cronjobs.yaml
@@ -63,6 +63,10 @@ spec:
               value: "{{ .Values.notifications.email_config.smtp_port | default "30025" }}"
             - name: REANA_COMPONENT_PREFIX
               value: {{ include "reana.prefix" . }}
+            - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
+              value: {{ .Values.default_runtime_namespace | default  .Release.Namespace }}
             - name: REANA_EMAIL_SENDER
               value: {{ .Values.notifications.email_config.sender }}
             - name: REANA_ADMIN_ACCESS_TOKEN

--- a/helm/reana/templates/ingress.yaml
+++ b/helm/reana/templates/ingress.yaml
@@ -7,6 +7,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "reana.prefix" . }}-ingress
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/reana/templates/kerberos-config.yaml
+++ b/helm/reana/templates/kerberos-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "reana.prefix" . }}-krb5-conf
+  namespace: {{ .Release.Namespace }}
 data:
   krb5.conf: |
         [libdefaults]

--- a/helm/reana/templates/reana-cache.yaml
+++ b/helm/reana/templates/reana-cache.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "reana.prefix" . }}-cache
+  namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort
   selector:
@@ -16,6 +17,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "reana.prefix" . }}-cache
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/helm/reana/templates/reana-db.yaml
+++ b/helm/reana/templates/reana-db.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "reana.prefix" . }}-db
+  namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort
   selector:
@@ -17,6 +18,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "reana.prefix" . }}-db
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/helm/reana/templates/reana-mail.yaml
+++ b/helm/reana/templates/reana-mail.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "reana.prefix" . }}-mail
+  namespace: {{ .Release.Namespace }}
 spec:
   type: "NodePort"
   ports:
@@ -24,6 +25,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "reana.prefix" . }}-mail
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/helm/reana/templates/reana-message-broker.yaml
+++ b/helm/reana/templates/reana-message-broker.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "reana.prefix" . }}-message-broker
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
    - port: 5672
@@ -20,6 +21,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "reana.prefix" . }}-message-broker
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "reana.prefix" . }}-server
+  namespace: {{ .Release.Namespace }}
 spec:
   type: "NodePort"
   ports:
@@ -17,6 +18,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "reana.prefix" . }}-server
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -29,7 +29,7 @@ spec:
       labels:
         app: {{ include "reana.prefix" . }}-server
     spec:
-      serviceAccountName: {{ include "reana.prefixed_svaccount_name" . }}
+      serviceAccountName: {{ include "reana.prefixed_infrastructure_svaccount_name" . }}
       containers:
       - name: rest-api
         image: {{ .Values.components.reana_server.image }}
@@ -58,6 +58,10 @@ spec:
         env:
           - name: REANA_COMPONENT_PREFIX
             value: {{ include "reana.prefix" . }}
+          - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
+            value: {{ .Release.Namespace }}
+          - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
+            value: {{ .Values.default_runtime_namespace | default  .Release.Namespace }}
           {{- range $key, $value := .Values.db_env_config }}
           - name: {{ $key }}
             value: {{ $value | quote }}
@@ -169,6 +173,10 @@ spec:
         env:
         - name: REANA_COMPONENT_PREFIX
           value: {{ include "reana.prefix" . }}
+        - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
+          value: {{ .Release.Namespace }}
+        - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
+          value: {{ .Values.default_runtime_namespace | default  .Release.Namespace }}
         {{- range $key, $value := .Values.db_env_config }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/helm/reana/templates/reana-shared-persistent-volume.yaml
+++ b/helm/reana/templates/reana-shared-persistent-volume.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "reana.prefix" . }}-shared-persistent-volume
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
   - {{ .Values.shared_storage.access_modes }}
@@ -18,6 +19,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ include "reana.prefix" . }}-shared-volume-storage-class
+  namespace: {{ .Release.Namespace }}
 provisioner: {{ .Values.shared_storage.cephfs.provisioner }}
 parameters:
   type: {{ .Values.shared_storage.cephfs.type }}

--- a/helm/reana/templates/reana-ui.yaml
+++ b/helm/reana/templates/reana-ui.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "reana.prefix" . }}-ui
+  namespace: {{ .Release.Namespace }}
 spec:
   type: "NodePort"
   ports:
@@ -18,6 +19,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "reana.prefix" . }}-ui
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/helm/reana/templates/reana-wdb.yaml
+++ b/helm/reana/templates/reana-wdb.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "reana.prefix" . }}-wdb
+  namespace: {{ .Release.Namespace }}
 spec:
   type: "NodePort"
   ports:
@@ -23,6 +24,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "reana.prefix" . }}-wdb
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -29,7 +29,7 @@ spec:
       labels:
         app: {{ include "reana.prefix" . }}-workflow-controller
     spec:
-      serviceAccountName: {{ include "reana.prefixed_svaccount_name" . }}
+      serviceAccountName: {{ include "reana.prefixed_infrastructure_svaccount_name" . }}
       containers:
       - name: rest-api
         image: {{ .Values.components.reana_workflow_controller.image }}
@@ -53,8 +53,10 @@ spec:
         env:
           - name: REANA_COMPONENT_PREFIX
             value: {{ include "reana.prefix" . }}
-          - name: REANA_KUBERNETES_NAMESPACE
+          - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
             value: {{ .Release.Namespace }}
+          - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
+            value: {{ .Values.default_runtime_namespace | default  .Release.Namespace }}
           {{- if .Values.naming_scheme }}
           - name: REANA_COMPONENT_NAMING_SCHEME
             value: {{ .Values.naming_scheme }}
@@ -67,8 +69,12 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}
-          - name: K8S_REANA_SERVICE_ACCOUNT_NAME
-            value: {{ include "reana.prefixed_svaccount_name" . }}
+          - name: REANA_INFRASTRUCTURE_KUBERNETES_SERVICEACCOUNT_NAME
+            value: {{ include "reana.prefixed_infrastructure_svaccount_name" . }}
+          {{- if .Values.default_runtime_namespace }}
+          - name: REANA_RUNTIME_KUBERNETES_SERVICEACCOUNT_NAME
+            value: {{ include "reana.prefixed_runtime_svaccount_name" . }}
+          {{- end }}
           - name: REANA_JOB_CONTROLLER_IMAGE
             value: {{ .Values.components.reana_job_controller.image }}
           - name: REANA_WORKFLOW_ENGINE_IMAGE_CWL
@@ -137,8 +143,10 @@ spec:
         env:
         - name: REANA_COMPONENT_PREFIX
           value: {{ include "reana.prefix" . }}
-        - name: REANA_KUBERNETES_NAMESPACE
+        - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
           value: {{ .Release.Namespace }}
+        - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
+          value: {{ .Values.default_runtime_namespace | default  .Release.Namespace }}
         {{- range $key, $value := .Values.db_env_config }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "reana.prefix" . }}-workflow-controller
+  namespace: {{ .Release.Namespace }}
 spec:
   type: "NodePort"
   ports:
@@ -17,6 +18,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "reana.prefix" . }}-workflow-controller
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
@@ -51,6 +53,8 @@ spec:
         env:
           - name: REANA_COMPONENT_PREFIX
             value: {{ include "reana.prefix" . }}
+          - name: REANA_KUBERNETES_NAMESPACE
+            value: {{ .Release.Namespace }}
           {{- if .Values.naming_scheme }}
           - name: REANA_COMPONENT_NAMING_SCHEME
             value: {{ .Values.naming_scheme }}
@@ -133,6 +137,8 @@ spec:
         env:
         - name: REANA_COMPONENT_PREFIX
           value: {{ include "reana.prefix" . }}
+        - name: REANA_KUBERNETES_NAMESPACE
+          value: {{ .Release.Namespace }}
         {{- range $key, $value := .Values.db_env_config }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/helm/reana/templates/roles.yaml
+++ b/helm/reana/templates/roles.yaml
@@ -30,5 +30,10 @@ roleRef:
   name: {{ include "reana.prefix" . }}-deployment-manager
 subjects:
 - kind: ServiceAccount
-  name: {{ include "reana.prefixed_svaccount_name" . }}
+  name: {{ include "reana.prefixed_infrastructure_svaccount_name" . }}
   namespace: {{ .Release.Namespace }}
+{{- if .Values.default_runtime_namespace }}
+- kind: ServiceAccount
+  name: {{ include "reana.prefixed_runtime_svaccount_name" . }}
+  namespace: {{ .Values.default_runtime_namespace }}
+{{- end }}

--- a/helm/reana/templates/roles.yaml
+++ b/helm/reana/templates/roles.yaml
@@ -2,8 +2,8 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: default
   name: {{ include "reana.prefix" . }}-deployment-manager
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["nodes", "nodes/status", "pods", "pods/log", "secrets", "persistentvolumeclaims", "configmaps"]
@@ -23,6 +23,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "reana.prefix" . }}-manage-deployments
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -30,4 +31,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "reana.prefixed_svaccount_name" . }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}

--- a/helm/reana/templates/secrets.yaml
+++ b/helm/reana/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "reana.prefix" . }}-db-secrets
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/resource-policy": keep
 type: Opaque
@@ -14,6 +15,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "reana.prefix" . }}-cern-sso-secrets
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/resource-policy": keep
 type: Opaque
@@ -25,6 +27,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "reana.prefix" . }}-cern-gitlab-secrets
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/resource-policy": keep
 type: Opaque
@@ -37,6 +40,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "reana.prefix" . }}-secrets
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/resource-policy": keep
 type: Opaque
@@ -48,6 +52,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "reana.prefix" . }}-mail-notification-sender-password
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/resource-policy": keep
 type: Opaque

--- a/helm/reana/templates/serviceaccount.yaml
+++ b/helm/reana/templates/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "reana.prefixed_svaccount_name" . }}
-  namespace: {{ .Values.serviceAccount.namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/reana/templates/serviceaccount.yaml
+++ b/helm/reana/templates/serviceaccount.yaml
@@ -1,5 +1,19 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "reana.prefixed_svaccount_name" . }}
+  name: {{ include "reana.prefixed_infrastructure_svaccount_name" . }}
   namespace: {{ .Release.Namespace }}
+{{- if .Values.default_runtime_namespace }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.default_runtime_namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "reana.prefixed_runtime_svaccount_name" . }}
+  namespace: {{ .Values.default_runtime_namespace }}
+{{- end }}

--- a/helm/reana/templates/uwsgi-config.yaml
+++ b/helm/reana/templates/uwsgi-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: uwsgi-config
+  namespace: {{ .Release.Namespace }}
 data:
   uwsgi.ini: |
     [uwsgi]

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -96,7 +96,6 @@ ingress:
 serviceAccount:
   create: true
   name: reana
-  namespace: default
 
 # Traefik's chart values.yaml
 traefik:
@@ -105,10 +104,6 @@ traefik:
     enabled: true
   dashboard:
     enabled: true
-  kubernetes:
-    namespaces:
-      - default
-      - kube-system
   serviceType: NodePort
   service:
     nodePorts:

--- a/reana/cli.py
+++ b/reana/cli.py
@@ -1869,12 +1869,12 @@ def kubectl_delete_pod(component):  # noqa: D301
 @cli.command(name="python-install-eggs")
 def python_install_eggs():
     """Create eggs-info/ in all REANA infrastructure and runtime components."""
-    python_cluster_components = [c for c in REPO_LIST_CLUSTER if c != "reana-ui"]
-    for component in python_cluster_components:
-        for cmd in [
-            "python setup.py bdist_egg",
-        ]:
-            run_command(cmd, component)
+    for component in REPO_LIST_CLUSTER:
+        if is_component_python_package(component):
+            for cmd in [
+                "python setup.py bdist_egg",
+            ]:
+                run_command(cmd, component)
 
 
 @cli.command(name="python-unit-tests")


### PR DESCRIPTION
* Use the Helm release namespace as the namespace where
  REANA will be running. Passes this configuration down to
  REANA-Workflow-Controller which will take care of creating
  all runtime pods so they run on the desired namespace
  (closes #274).
* Allows having two different namespaces for infrastructure and runtime
  pods (closes #268).
