### PR TITLE
installation: packaging dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ install_requires = [
     "colorama>=0.3.9",
     "PyYAML>=5.1",
     "semver>=2.10.2",
+    "packaging>=20.4",
 ]
 
 


### PR DESCRIPTION
Declares dependency on `packaging` module, fixing `reana-dev
git-clone` issues on from-scratch installations. Closes #382.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>