### PR TITLE
helm: enable reana-ui by default

### DIFF
--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -48,7 +48,8 @@ db_env_config:
 # REANA components configuration
 components:
   reana_ui:
-    enabled: false
+    enabled: true
+    docs_url: http://docs.reana.io
     imagePullPolicy: IfNotPresent
     image: reanahub/reana-ui:0.7.0-alpha.1
   reana_db:


### PR DESCRIPTION
Allows excluding reana-ui from cluster deploy.

closes reanahub/reana-ui#114
depends on https://github.com/reanahub/pytest-reana/pull/65