### PR TITLE
config: prefetch docker images for BSM demo

### DIFF
--- a/reana/config.py
+++ b/reana/config.py
@@ -160,6 +160,10 @@ DOCKER_PREFETCH_IMAGES = {
         "reanahub/reana-demo-atlas-recast-eventselection:1.0",
         "reanahub/reana-demo-atlas-recast-statanalysis:1.0",
     ],
+    "reana-demo-bsm-search": [
+        "reanahub/reana-demo-bsm-search:1.0.0",
+        "reanahub/reana-env-root6:6.18.04",
+    ],
 }
 """Images to be prefetched depending on the REANA demo to be executed."""
 


### PR DESCRIPTION
Adds Docker images to prefetch for the `reana-demo-bsm-search` example
following up its 1.0.0 release.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>