### PR TITLE
helm: Kubernetes 1.19

### DIFF
--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
 type: application
 # Chart version.
 version: 0.7.0-alpha.1
-kubeVersion: ">= 1.13.0-0 < 1.19.0-0"
+kubeVersion: ">= 1.13.0-0 < 1.20.0-0"
 dependencies:
   - name: traefik
     version: 1.85.x


### PR DESCRIPTION
Declares support for Kubernetes 1.19 that was successfully tested
using Kind 0.9.0.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>