### PR TITLE
index.yaml: fix 0.7.0-alpha.1 release link

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -39,6 +39,6 @@ entries:
     - https://github.com/reanahub/www.reana.io
     type: application
     urls:
-    - https://github.com/reanahub/reana/releases/download/reana-0.7.0-alpha.1/reana-0.7.0-alpha.1.tgz
+    - https://github.com/reanahub/reana/releases/download/0.7.0-alpha.1/0.7.0-alpha.1.tgz
     version: 0.7.0-alpha.1
 generated: "2020-04-16T13:43:48.101308579Z"


### PR DESCRIPTION
As the last step of cleaning up the [current REANA releases](https://github.com/reanahub/reana/releases) we are missing to remove https://github.com/reanahub/reana/releases/tag/reana-0.7.0-alpha.1 which was created by the CR GitHub action and use https://github.com/reanahub/reana/releases/tag/0.7.0-alpha.1 which is correctly named.

To do:
- [x] Manually create the `.tgz` file and add it to the current `0.7.0-alpha.1` release ([now returns a 404](https://github.com/reanahub/reana/releases/download/0.7.0-alpha.1/0.7.0-alpha.1.tgz))
