### PR TITLE
cli: replacing strings better error messages

### DIFF
--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -391,6 +391,14 @@ def replace_string(
             f'cat {file_} | grep -n -e "{line_selector_regex}" | cut -f1 -d: ',
             return_output=True,
         )
+        if not line:
+            click.secho(
+                f"[ERROR] Could not find `{line_selector_regex}` in {component}'s"
+                f" `{file_}`. Please check `{file_}`.",
+                err=True,
+                fg="red",
+            ),
+            sys.exit(1)
 
     cmd = (
         f"sed -i.bk '{line}s/{find}/{replace}/' {file_} && [ -e {file_}.bk ]"


### PR DESCRIPTION
* Currently, if the line selector is not found in the file
  the `line` variable is empty. This triggers a wrong update
  of any line in the file that matches the `find` variable,
  typically many.