### PR TITLE
cli: richer git-log command

### DIFF
--- a/reana/version.py
+++ b/reana/version.py
@@ -13,4 +13,4 @@ This file is imported by ``reana.__init__`` and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200224"
+__version__ = "0.8.0a0"

--- a/tests/benchmark/locustfile.py
+++ b/tests/benchmark/locustfile.py
@@ -65,12 +65,12 @@ class WorkflowsTaskSet(TaskSet):
     @task
     def ping(self):
         """Ping reana instance."""
-        self.client.get(f"/api/ping")
+        self.client.get("/api/ping")
 
     @task
     def get_worflows(self):
         """Get workflows."""
-        self.client.get(f"/api/workflows", params=(("access_token", TOKEN),))
+        self.client.get("/api/workflows", params=(("access_token", TOKEN),))
 
     @task
     def get_worflow_logs(self):


### PR DESCRIPTION
Adds new options to git-log command to show patch or to pass any
wanted argument.

Examples:

$ reana-dev git-log -c CLIENT -n 5 -p --paginate
$ reana-dev git-log -c CLIENT -n 3 --stat --oneline
$ reana-dev git-log -c CLIENT --graph --all
$ reana-dev git-log -c CLIENT master..maint-0.7
$ reana-dev git-log -c CLUSTER -c CLIENT master..maint-0.7 \
      --exclude-components r-a-vomsproxy,r-a-krb5