### PR TITLE
cli: git-upgrade skip on missing branch

### DIFF
--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -54,6 +54,17 @@ def get_all_branches(srcdir):
     )
 
 
+def branch_exists(component, branch):
+    """Check whether a branch exists on a given component.
+
+    :param component: Component in which check whether the branch exists.
+    :param branch: Name of the branch.
+    :return: Whether the branch exists in components git repo.
+    :rtype: bool
+    """
+    return branch in get_all_branches(get_srcdir(component))
+
+
 def get_current_branch(srcdir):
     """Return current Git branch name checked out in the given directory.
 
@@ -604,7 +615,7 @@ def git_checkout(branch, component, fetch):  # noqa: D301
     for component in select_components(component):
         if fetch:
             run_command("git fetch upstream", component)
-        if branch in get_all_branches(get_srcdir(component)):
+        if branch_exists(component, branch):
             run_command("git checkout {}".format(branch), component)
         else:
             click.secho(
@@ -768,6 +779,11 @@ def git_upgrade(component, base):  # noqa: D301
     :type base: str
     """
     for component in select_components(component):
+        if not branch_exists(component, base):
+            display_message(
+                "Missing branch {}, skipping.".format(base), component=component
+            )
+            continue
         for cmd in [
             "git fetch upstream",
             "git checkout {0}".format(base),


### PR DESCRIPTION
We have a few components without `maint-0.7` branch, which results in:
```
$ reana-dev git-upgrade --base maint-0.7
...
[2020-11-09T14:13:33] reana-auth-krb5: git fetch upstream
[2020-11-09T14:13:35] reana-auth-krb5: git checkout maint-0.7
error: pathspec 'maint-0.7' did not match any file(s) known to git
[2020-11-09T14:13:35] reana-auth-krb5: Command 'git checkout maint-0.7' returned non-zero exit status 1.
```

With this PR one gets:
```
$ reana-dev git-upgrade --base maint-0.7
...
[2020-11-09T14:15:00] reana-workflow-engine-serial: git push origin maint-0.7
Everything up-to-date
[2020-11-09T14:15:02] reana-workflow-engine-serial: git checkout -
Already on 'maint-0.7'
Your branch is up to date with 'upstream/maint-0.7'.
[2020-11-09T14:15:02] reana-auth-krb5: Missing branch maint-0.7, skipping.
[2020-11-09T14:15:02] reana-auth-vomsproxy: Missing branch maint-0.7, skipping.
[2020-11-09T14:15:02] reana-server: git fetch upstream
[2020-11-09T14:15:04] reana-server: git checkout maint-0.7
...
```

This approach seems dangerous since one could ignore upgrades on certain components (e.g. `r-server`) because of a missing fetch instruction (e.g. `reana-dev git-fetch -c r-server`). We could follow the [`--exclude-components`](https://github.com/reanahub/reana/blob/8bbd737f0bf41bfae8ae60f6fe61d6e73a5b9371/reana/reana_dev/kind.py#L35-L38) option approach instead.