### PR TITLE
cli: `git-*` commands completed with `--exclude-components` option

### DIFF
--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -320,8 +320,13 @@ def git_fork(component, browser):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components",
+    default="",
+    help="Which components to exclude from command? [c1,c2,c3]",
+)
 @git_commands.command(name="git-clone")
-def git_clone(user, component):  # noqa: D301
+def git_clone(user, component, exclude_components):  # noqa: D301
     """Clone REANA source repositories from GitHub.
 
     If the ``user`` argument is provided, the ``origin`` will be cloned from
@@ -334,6 +339,7 @@ def git_clone(user, component):  # noqa: D301
     shallow to save disk space and CPU time. Useful for CI purposes.
 
     \b
+    :param user: The GitHub user name. [default=anonymous]
     :param components: The option ``component`` can be repeated. The value may
                        consist of:
                          * (1) standard component name such as
@@ -349,12 +355,14 @@ def git_clone(user, component):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
-    :param user: The GitHub user name. [default=anonymous]
-    :type component: str
+    :param exclude_components: List of components to exclude from command.
     :type user: str
-
+    :type component: str
+    :type exclude_components: str
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     for component in components:
         os.chdir(get_srcdir())
         if os.path.exists("{0}/.git/config".format(component)):
@@ -385,6 +393,11 @@ def git_clone(user, component):  # noqa: D301
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
 @click.option(
+    "--exclude-components",
+    default="",
+    help="Which components to exclude from command? [c1,c2,c3]",
+)
+@click.option(
     "--short",
     "-s",
     is_flag=True,
@@ -393,7 +406,7 @@ def git_clone(user, component):  # noqa: D301
 )
 @git_commands.command(name="git-status")
 @click_add_git_base_branch_option
-def git_status(component, short, base):  # noqa: D301
+def git_status(component, exclude_components, short, base):  # noqa: D301
     """Report status of REANA source repositories.
 
     \b
@@ -412,12 +425,16 @@ def git_status(component, short, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude from command.
     :param base: Against which git base branch are we working? [default=master]
     :param verbose: Show git status details? [default=False]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     for component in components:
         current_branch = get_current_branch(get_srcdir(component))
         # detect all local and remote branches
@@ -753,9 +770,14 @@ def git_fetch(component):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components",
+    default="",
+    help="Which components to exclude from command? [c1,c2,c3]",
+)
 @git_commands.command(name="git-upgrade")
 @click_add_git_base_branch_option
-def git_upgrade(component, base):  # noqa: D301
+def git_upgrade(component, exclude_components, base):  # noqa: D301
     """Upgrade REANA local source code repositories and push to GitHub origin.
 
     \b
@@ -774,11 +796,16 @@ def git_upgrade(component, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude from command.
     :param base: Against which git base branch are we working on? [default=master]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
+    for component in components:
         if not branch_exists(component, base):
             display_message(
                 "Missing branch {}, skipping.".format(base), component=component
@@ -805,7 +832,7 @@ def git_upgrade(component, base):  # noqa: D301
 @click.option(
     "--exclude-components",
     default="",
-    help="Which components to exclude from build? [c1,c2,c3]",
+    help="Which components to exclude from command? [c1,c2,c3]",
 )
 @click.option("--number", "-n", default=10, help="Number of commits to output [10]")
 @click.option("--graph", is_flag=True, default=False, help="Show log graph?")
@@ -846,7 +873,7 @@ def git_log(
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
-    :param exclude_components: List of components to exclude from the build.
+    :param exclude_components: List of components to exclude from command.
     :param number: The number of commits to output. [10]
     :param graph: Show log graph?
     :param oneline: Show one-line format?
@@ -903,9 +930,14 @@ def git_log(
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components",
+    default="",
+    help="Which components to exclude from command? [c1,c2,c3]",
+)
 @git_commands.command(name="git-diff")
 @click_add_git_base_branch_option
-def git_diff(component, base):  # noqa: D301
+def git_diff(component, exclude_components, base):  # noqa: D301
     """Diff checked-out REANA local source code repositories.
 
     \b
@@ -924,11 +956,16 @@ def git_diff(component, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude from command.
     :param base: Against which git base branch are we working on? [default=master]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
+    for component in components:
         for cmd in [
             "git diff {}".format(base),
         ]:
@@ -942,9 +979,14 @@ def git_diff(component, base):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [name|CLUSTER]",
 )
+@click.option(
+    "--exclude-components",
+    default="",
+    help="Which components to exclude from command? [c1,c2,c3]",
+)
 @git_commands.command(name="git-push")
 @click_add_git_base_branch_option
-def git_push(component, base):  # noqa: D301
+def git_push(component, exclude_components, base):  # noqa: D301
     """Push REANA local repositories to GitHub origin.
 
     \b
@@ -963,11 +1005,15 @@ def git_push(component, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude from command.
     :param base: Against which git base branch are we working on? [default=master]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     for component in components:
         for cmd in ["git push origin {}".format(base)]:
             run_command(cmd, component)
@@ -1106,9 +1152,14 @@ def git_create_release_commit_command(component, version):  # noqa: D301
     multiple=True,
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components",
+    default="",
+    help="Which components to exclude from command? [c1,c2,c3]",
+)
 @git_commands.command(name="git-create-pr")
 @click_add_git_base_branch_option
-def git_create_pr_command(component, base):  # noqa: D301
+def git_create_pr_command(component, exclude_components, base):  # noqa: D301
     """Create a GitHub pull request for each selected component.
 
     \b
@@ -1127,8 +1178,10 @@ def git_create_pr_command(component, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude from command.
     :param base: Against which git base branch are we working on? [default=master]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
 
@@ -1141,7 +1194,10 @@ def git_create_pr_command(component, base):  # noqa: D301
         ]:
             run_command(cmd, component)
 
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
+    for component in components:
         if not is_feature_branch(component):  # replace with is_feature_branch from #371
             display_message(
                 "You are trying to create PR but the current branch is base branch {}, please "


### PR DESCRIPTION
Adds `--exclude-components` option to many `git-*` commands, allowing
to do things like:

$ reana-dev git-status -c CLIENT -c CLUSTER --base maint-0.7 \
    --exclude-components r-a-vomsproxy,r-a-krb5