### PR TITLE
helm: update Ingress API for k8s>=1.19

### DIFF
--- a/helm/reana/templates/ingress.yaml
+++ b/helm/reana/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1
@@ -17,18 +19,45 @@ spec:
     - http:
         paths:
         - path: /api
+          {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ include "reana.prefix" . }}-server
+              port:
+                number: 80
+          {{- else }}
           backend:
             serviceName: {{ include "reana.prefix" . }}-server
             servicePort: 80
+          {{- end }}
         - path: /oauth
+          {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ include "reana.prefix" . }}-server
+              port:
+                number: 80
+          {{- else }}
           backend:
             serviceName: {{ include "reana.prefix" . }}-server
             servicePort: 80
+          {{- end }}
         {{- if .Values.components.reana_ui.enabled }}
         - path: /
+          {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ include "reana.prefix" . }}-ui
+              port:
+                number: 80
+          {{- else }}
           backend:
             serviceName: {{ include "reana.prefix" . }}-ui
             servicePort: 80
+          {{- end }}
         {{- end }}
       {{- if .Values.reana_hostname }}
       host: {{ .Values.reana_hostname }}


### PR DESCRIPTION
* Helm 3.4 warns about this, more in the [docs](https://kubernetes.io/docs/concepts/services-networking/ingress/).