### PR TITLE
helm: expose user_confirmation flag to ui config

### DIFF
--- a/helm/reana/README.md
+++ b/helm/reana/README.md
@@ -12,7 +12,7 @@ This Helm automatically prefixes all names using the release name to avoid colli
 | `components.reana_job_controller.image`                  | [REANA-Job-Controller image](https://hub.docker.com/r/reanahub/reana-job-controller) to use  | `reanahub/reana-job-controller:<chart-release-version>` |
 | `components.reana_message_broker.image`                  | [REANA-Message-Broker image](https://hub.docker.com/r/reanahub/reana-message-broker) to use | `reanahub/reana-message-broker:<chart-release-version>` |
 | `components.reana_message_broker.imagePullPolicy`        | REANA-Message-Broker image pull policy                                               | IfNotPresent                                    |
-| `components.reana_server.environment`                    | REANA-Server environment variables                                                   | {REANA_MAX_CONCURRENT_BATCH_WORKFLOWS: 30}      |
+| `components.reana_server.environment`                    | REANA-Server environment variables                                                   | {REANA_MAX_CONCURRENT_BATCH_WORKFLOWS: 30, REANA_USER_CONFIRMATION: true}      |
 | `components.reana_server.image`                          | [REANA-Server image](https://hub.docker.com/r/reanahub/reana-server) to use          | `reanahub/reana-server:<chart-release-version>` |
 | `components.reana_server.imagePullPolicy`                | REANA-Server image pull policy                                                       | IfNotPresent                                    |
 | `components.reana_server.uwsgi.processes`                | Number of uWSGI processes                                                            | 6                                               |

--- a/helm/reana/templates/ui-config.yaml
+++ b/helm/reana/templates/ui-config.yaml
@@ -20,3 +20,8 @@ data:
     {{- else }}
     local_users: false
     {{- end }}
+    {{- if or (.Values.components.reana_server.environment.REANA_USER_CONFIRMATION) (eq (.Values.components.reana_server.environment.REANA_USER_CONFIRMATION | toString) "<nil>") }}
+    user_confirmation: true
+    {{- else }}
+    user_confirmation: false
+    {{- end }}

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -60,6 +60,7 @@ components:
     image: reanahub/reana-server:0.7.1
     environment:
       REANA_MAX_CONCURRENT_BATCH_WORKFLOWS: 30
+      REANA_USER_CONFIRMATION: true
     uwsgi:
       processes: 6
       threads: 4


### PR DESCRIPTION
closes #472

By default, user confirmation is enabled, to disable it add env var `REANA_USER_CONFIRMATION: false` in `values.yaml`:
```diff
@@ -60,6 +77,7 @@ components:
     image: reanahub/reana-server:0.7.1
     environment:
       REANA_MAX_CONCURRENT_BATCH_WORKFLOWS: 30
+      REANA_USER_CONFIRMATION: false
     uwsgi:
       processes: 6
       threads: 4
```