### PR TITLE
cli: `--exclude-components` for `git-*` commands

### DIFF
--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2021 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -254,10 +254,13 @@ def git_commands():
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
 @click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
+@click.option(
     "--browser", "-b", default="firefox", help="Which browser to use? [firefox]"
 )
 @git_commands.command(name="git-fork")
-def git_fork(component, browser):  # noqa: D301
+def git_fork(component, exclude_components, browser):  # noqa: D301
     """Display commands to fork REANA source code repositories on GitHub.
 
     \b
@@ -276,11 +279,15 @@ def git_fork(component, browser):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :param browser: The web browser to use. [default=firefox]
     :type component: str
+    :type exclude_components: str
     :type browser: str
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     if components:
         click.echo("# Fork REANA repositories on GitHub using your browser.")
         click.echo(
@@ -309,8 +316,11 @@ def git_fork(component, browser):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @git_commands.command(name="git-clone")
-def git_clone(user, component):  # noqa: D301
+def git_clone(user, component, exclude_components):  # noqa: D301
     """Clone REANA source repositories from GitHub.
 
     If the ``user`` argument is provided, the ``origin`` will be cloned from
@@ -338,12 +348,16 @@ def git_clone(user, component):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :param user: The GitHub user name. [default=anonymous]
     :type component: str
+    :type exclude_components: str
     :type user: str
 
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     for component in components:
         os.chdir(get_srcdir())
         if os.path.exists("{0}/.git/config".format(component)):
@@ -374,6 +388,9 @@ def git_clone(user, component):  # noqa: D301
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
 @click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
+@click.option(
     "--short",
     "-s",
     is_flag=True,
@@ -382,7 +399,7 @@ def git_clone(user, component):  # noqa: D301
 )
 @git_commands.command(name="git-status")
 @click_add_git_base_branch_option
-def git_status(component, short, base):  # noqa: D301
+def git_status(component, exclude_components, short, base):  # noqa: D301
     """Report status of REANA source repositories.
 
     \b
@@ -401,12 +418,16 @@ def git_status(component, short, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :param base: Against which git base branch are we working? [default=master]
     :param verbose: Show git status details? [default=False]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     for component in components:
         current_branch = get_current_branch(get_srcdir(component))
         # detect all local and remote branches
@@ -432,8 +453,11 @@ def git_status(component, short, base):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @git_commands.command(name="git-clean")
-def git_clean(component):  # noqa: D301
+def git_clean(component, exclude_components):  # noqa: D301
     """Clean REANA source repository code tree.
 
     Removes all non-source-controlled files in the component source code
@@ -455,9 +479,13 @@ def git_clean(component):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :type component: str
+    :type exclude_components: str
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     for component in components:
         for cmd in [
             "git clean -d -ff -x",
@@ -538,8 +566,11 @@ def git_submodule(update=False, status=False, delete=False):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @git_commands.command(name="git-branch")
-def git_branch(component):  # noqa: D301
+def git_branch(component, exclude_components):  # noqa: D301
     """Display information about locally checked-out branches.
 
     \b
@@ -558,9 +589,13 @@ def git_branch(component):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :type component: str
+    :type exclude_components: str
     """
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    for component in select_components(component, exclude_components):
         cmd = "git branch -vv"
         run_command(cmd, component)
 
@@ -573,9 +608,12 @@ def git_branch(component):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @click.option("--fetch", is_flag=True, default=False)
 @git_commands.command(name="git-checkout")
-def git_checkout(branch, component, fetch):  # noqa: D301
+def git_checkout(branch, component, exclude_components, fetch):  # noqa: D301
     """Check out given local branch in desired components.
 
     \b
@@ -595,13 +633,16 @@ def git_checkout(branch, component, fetch):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
-    :type component: str
+    :param exclude_components: List of components to exclude.
     :param fetch: Should we fetch latest upstream first? [default=False]
     :type branch: str
     :type component: list
+    :type exclude_components: str
     :type fetch: bool
     """
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    for component in select_components(component, exclude_components):
         if fetch:
             run_command("git fetch upstream", component)
         if branch in get_all_branches(get_srcdir(component)):
@@ -708,8 +749,11 @@ def git_merge(branch, base, push):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @git_commands.command(name="git-fetch")
-def git_fetch(component):  # noqa: D301
+def git_fetch(component, exclude_components):  # noqa: D301
     """Fetch REANA upstream source code repositories without upgrade.
 
     \b
@@ -728,9 +772,13 @@ def git_fetch(component):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :type component: str
+    :type exclude_components: str
     """
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    for component in select_components(component, exclude_components):
         cmd = "git fetch upstream"
         run_command(cmd, component)
 
@@ -742,9 +790,12 @@ def git_fetch(component):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @git_commands.command(name="git-upgrade")
 @click_add_git_base_branch_option
-def git_upgrade(component, base):  # noqa: D301
+def git_upgrade(component, exclude_components, base):  # noqa: D301
     """Upgrade REANA local source code repositories and push to GitHub origin.
 
     \b
@@ -763,11 +814,15 @@ def git_upgrade(component, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :param base: Against which git base branch are we working on? [default=master]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    for component in select_components(component, exclude_components):
         for cmd in [
             "git fetch upstream",
             "git checkout {0}".format(base),
@@ -785,10 +840,13 @@ def git_upgrade(component, base):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @click.option("--number", "-n", default=6, help="Number of commits to output [6]")
 @click.option("--all", is_flag=True, default=False, help="Show all references?")
 @git_commands.command(name="git-log")
-def git_log(component, number, all):  # noqa: D301
+def git_log(component, exclude_components, number, all):  # noqa: D301
     """Show commit logs in given component repositories.
 
     \b
@@ -807,13 +865,17 @@ def git_log(component, number, all):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :param number: The number of commits to output. [6]
     :param all: Show all references? [6]
     :type component: str
+    :type exclude_components: str
     :type number: int
     :type all: bool
     """
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    for component in select_components(component, exclude_components):
         cmd = (
             "git log -n {0} --graph --decorate"
             ' --pretty=format:"%C(blue)%d%Creset'
@@ -834,9 +896,12 @@ def git_log(component, number, all):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @git_commands.command(name="git-diff")
 @click_add_git_base_branch_option
-def git_diff(component, base):  # noqa: D301
+def git_diff(component, exclude_components, base):  # noqa: D301
     """Diff checked-out REANA local source code repositories.
 
     \b
@@ -855,11 +920,15 @@ def git_diff(component, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :param base: Against which git base branch are we working on? [default=master]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    for component in select_components(component, exclude_components):
         for cmd in [
             "git diff {}".format(base),
         ]:
@@ -873,9 +942,12 @@ def git_diff(component, base):  # noqa: D301
     default=["CLUSTER"],
     help="Which components? [name|CLUSTER]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @git_commands.command(name="git-push")
 @click_add_git_base_branch_option
-def git_push(component, base):  # noqa: D301
+def git_push(component, exclude_components, base):  # noqa: D301
     """Push REANA local repositories to GitHub origin.
 
     \b
@@ -894,11 +966,15 @@ def git_push(component, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :param base: Against which git base branch are we working on? [default=master]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     for component in components:
         for cmd in ["git push origin {}".format(base)]:
             run_command(cmd, component)
@@ -911,6 +987,9 @@ def git_push(component, base):  # noqa: D301
     multiple=True,
     default=["CLUSTER", "CLIENT"],
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
+)
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
 )
 @click.option(
     "--use-latest-known-tag",
@@ -935,7 +1014,7 @@ def git_push(component, base):  # noqa: D301
 )
 @click.pass_context
 def git_upgrade_shared_modules(
-    ctx, component, use_latest_known_tag, amend, push
+    ctx, component, exclude_components, use_latest_known_tag, amend, push
 ):  # noqa: D301
     """Upgrade selected components to latest REANA-Commons/DB version.
 
@@ -955,7 +1034,9 @@ def git_upgrade_shared_modules(
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :type component: str
+    :type exclude_components: str
     """
 
     def _create_commit_or_amend(components):
@@ -971,7 +1052,9 @@ def git_upgrade_shared_modules(
                 f"git add {' '.join(files_to_commit)} && {commit_cmd}", c,
             )
 
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
 
     for module in REPO_LIST_SHARED:
         last_version = fetch_latest_pypi_version(module)
@@ -997,10 +1080,15 @@ def git_upgrade_shared_modules(
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
 @click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
+@click.option(
     "--version", "-v", help="Shall we manually specify component's next version?",
 )
 @git_commands.command(name="git-create-release-commit")
-def git_create_release_commit_command(component, version):  # noqa: D301
+def git_create_release_commit_command(
+    component, exclude_components, version
+):  # noqa: D301
     """Create a release commit for the specified components.
 
     \b
@@ -1019,12 +1107,16 @@ def git_create_release_commit_command(component, version):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :param version: Manually specifies the version for the component. If not provided,
         the last version will be auto-incremented..
     :type component: str
+    :type exclude_components: str
     :type version: str
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     for component in components:
         if git_create_release_commit(component, next_version=version):
             display_message("Release commit created.", component)
@@ -1037,9 +1129,12 @@ def git_create_release_commit_command(component, version):  # noqa: D301
     multiple=True,
     help="Which components? [shortname|name|.|CLUSTER|ALL]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @git_commands.command(name="git-create-pr")
 @click_add_git_base_branch_option
-def git_create_pr_command(component, base):  # noqa: D301
+def git_create_pr_command(component, exclude_components, base):  # noqa: D301
     """Create a GitHub pull request for each selected component.
 
     \b
@@ -1058,8 +1153,10 @@ def git_create_pr_command(component, base):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :param base: Against which git base branch are we working on? [default=master]
     :type component: str
+    :type exclude_components: str
     :type base: str
     """
 
@@ -1072,7 +1169,9 @@ def git_create_pr_command(component, base):  # noqa: D301
         ]:
             run_command(cmd, component)
 
-    for component in select_components(component):
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    for component in select_components(component, exclude_components):
         if not is_feature_branch(component):  # replace with is_feature_branch from #371
             display_message(
                 "You are trying to create PR but the current branch is base branch {}, please "
@@ -1101,8 +1200,11 @@ def git_create_pr_command(component, base):  # noqa: D301
     multiple=True,
     help="Which components? [name|CLUSTER]",
 )
+@click.option(
+    "--exclude-components", default="", help="Which components to exclude? [c1,c2,c3]",
+)
 @git_commands.command(name="git-tag")
-def git_tag(component):  # noqa: D301
+def git_tag(component, exclude_components):  # noqa: D301
     """Create the corresponding git tag for components with release commits.
 
     \b
@@ -1121,9 +1223,12 @@ def git_tag(component):  # noqa: D301
                                to include several runable REANA demo examples;
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
+    :param exclude_components: List of components to exclude.
     :type component: str
     """
-    components = select_components(component)
+    if exclude_components:
+        exclude_components = exclude_components.split(",")
+    components = select_components(component, exclude_components)
     for component in components:
         if not is_last_commit_release_commit(component):
             click.secho(


### PR DESCRIPTION
Adds `--exclude-components` option to all `reana-dev git-*` commands.
Allows to run useful branch-specific commands such as:

$ reana-dev git-upgrade -c CLUSTER -c CLIENT --base maint-0.7 \
       --exclude-components r-a-krb5,r-a-vomsproxy