### PR TITLE
cli: enrich run-example to run full test matrix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Version 0.7.3 (UNRELEASED)
     - Adds new configuration to toggle Kubernetes user jobs clean up.
       (``REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES`` in ``components.reana_workflow_controller.environment``)
     - Improves platform resilience.
+- Developers:
+    - Adds new flags to ``reana-dev run-example`` allowing full paralell test matrix execution
+      (``--compute-backend``, ``--submit-only`` and ``--check-only``).
 
 Version 0.7.2 (2021-02-04)
 --------------------------

--- a/reana/config.py
+++ b/reana/config.py
@@ -89,6 +89,9 @@ REPO_LIST_SHARED = [
 WORKFLOW_ENGINE_LIST_ALL = ["cwl", "serial", "yadage"]
 """List of supported workflow engines."""
 
+COMPUTE_BACKEND_LIST_ALL = ["kubernetes", "htcondorcern", "slurmcern"]
+"""List of supported compute backends."""
+
 CLUSTER_DEPLOYMENT_MODES = ["releasehelm", "releasepypi", "latest", "debug"]
 """List of supported modes to run a REANA cluster."""
 
@@ -100,6 +103,16 @@ COMPONENT_PODS = {
     "reana-ui": "reana-ui",
 }
 """Component pods by repository name."""
+
+EXAMPLE_NON_STANDARD_REANA_YAML_FILENAME = {
+    "reana-demo-atlas-recast": {
+        "yadage": {
+            "htcondorcern": "reana-htcondorcern.yaml",
+            "kubernetes": "reana.yaml",
+        },
+    }
+}
+"""List of non standard REANA demo's reana.yaml file names."""
 
 EXAMPLE_OUTPUT_FILENAMES = {
     "reana-demo-helloworld": ("greetings.txt",),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,10 +170,15 @@ def test_construct_workflow_name():
     from reana.reana_dev.run import construct_workflow_name
 
     for (input_value, output_expected) in (
-        (("reana", "cwl"), "reana-cwl"),
-        (("reana-demo-root6-roofit", "yadage"), "root6-roofit-yadage"),
+        (("reana", "cwl", "kubernetes"), "reana-cwl-kubernetes"),
+        (
+            ("reana-demo-root6-roofit", "yadage", "htcondorcern"),
+            "root6-roofit-yadage-htcondorcern",
+        ),
     ):
-        output_obtained = construct_workflow_name(input_value[0], input_value[1])
+        output_obtained = construct_workflow_name(
+            input_value[0], input_value[1], input_value[2]
+        )
         assert output_obtained == output_expected
 
 


### PR DESCRIPTION
Extends `reana-dev run-example` to be able to specify compute backends, making it easier to test https://github.com/reanahub/reana-job-controller/issues/304 and allow richer CI scnearios:
```
$ reana-dev run-example --compute-backend ALL --timeout 1800
[2021-03-09T15:17:02] : Running the following matrix:
Demos: ['reana-demo-worldpopulation', 'reana-demo-helloworld', 'reana-demo-root6-roofit', 'reana-demo-atlas-recast']
Workflow engines:['serial', 'yadage', 'cwl']
Compute backends: ['kubernetes', 'htcondorcern', 'slurmcern']
Number of workflows: 36
```

Closes https://github.com/reanahub/reana-job-controller/issues/304.


Caveats:
- ~~Slow: Non-parallelisable for the moment~~
- ~~`TIMEOUT` needs to be increased due to HTCondor and Slurm taking longer to execute~~