### PR TITLE
cli: remove click option default when multiple=True

### DIFF
--- a/reana/reana_dev/cluster.py
+++ b/reana/reana_dev/cluster.py
@@ -159,7 +159,6 @@ def cluster_create(mounts, mode, worker_nodes):  # noqa: D301
 @click.option(
     "--build-arg",
     "-b",
-    default="",
     multiple=True,
     help="Any build arguments? (e.g. `-b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern`)",
 )

--- a/reana/reana_dev/docker.py
+++ b/reana/reana_dev/docker.py
@@ -47,11 +47,7 @@ def docker_commands():
     help="Which components to exclude from build? [c1,c2,c3]",
 )
 @click.option(
-    "--build-arg",
-    "-b",
-    default="",
-    multiple=True,
-    help="Any build arguments? (e.g. `-b DEBUG=1`)",
+    "--build-arg", "-b", multiple=True, help="Any build arguments? (e.g. `-b DEBUG=1`)",
 )
 @click.option("--no-cache", is_flag=True)
 @click.option(

--- a/reana/reana_dev/run.py
+++ b/reana/reana_dev/run.py
@@ -205,7 +205,6 @@ def run_commands():
 @click.option(
     "--build-arg",
     "-b",
-    default="",
     multiple=True,
     help="Any build arguments? (e.g. `-b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern`)",
 )


### PR DESCRIPTION
From `click 8.0.0`, `default` must be a list or a tuple for options that are `multiple=True`.
https://click.palletsprojects.com/en/8.0.x/options/?highlight=multiple#multiple-options

closes #503