### PR TITLE
helm: make ui configmap more generic

### DIFF
--- a/helm/reana/templates/reana-config.yaml
+++ b/helm/reana/templates/reana-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ui-config
+  name: reana-config
   namespace: {{ .Release.Namespace }}
 data:
   ui-config.yaml: |

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -55,7 +55,7 @@ spec:
             name: reana-shared-volume
           - name: uwsgi-config
             mountPath: '/var/reana/uwsgi'
-          - name: ui-config
+          - name: reana-config
             mountPath: '/var/reana/config'
         env:
           - name: REANA_COMPONENT_PREFIX
@@ -235,10 +235,10 @@ spec:
         configMap:
           defaultMode: 420
           name: uwsgi-config
-      - name: ui-config
+      - name: reana-config
         configMap:
           defaultMode: 420
-          name: ui-config
+          name: reana-config
       {{- if .Values.node_label_infrastructure }}
       {{- $full_label := split "=" .Values.node_label_infrastructure }}
       nodeSelector:


### PR DESCRIPTION
Introduce scheduler configuration in reana-config.

closes reanahub/reana-server#356

#### To test

1. Checkout reanahub/reana-server#356 PR set
2. Observe in a terminal the output of `kubectl logs deployment/reana-server scheduler -f`
3. Run multiple workflows and observe how priorities get lower when there're already other workflows running.

```console
2021-06-09 12:51:59,822 | root | MainThread | INFO | Starting queued workflow: {'user': '00000000-0000-0000-0000-000000000000', 'workflow_id_or_name': 'roofit.5', 'parameters': {'input_parameters': {}, 'operational_options': {}}, 'priority': 97}
...
2021-06-09 12:52:04,441 | root | MainThread | INFO | Starting queued workflow: {'user': '00000000-0000-0000-0000-000000000000', 'workflow_id_or_name': 'roofit.6', 'parameters': {'input_parameters': {}, 'operational_options': {}}, 'priority': 78}
...
2021-06-09 12:52:07,794 | root | MainThread | INFO | Starting queued workflow: {'user': '00000000-0000-0000-0000-000000000000', 'workflow_id_or_name': 'roofit.7', 'parameters': {'input_parameters': {}, 'operational_options': {}}, 'priority': 58}
...
2021-06-09 12:52:10,696 | root | MainThread | INFO | Starting queued workflow: {'user': '00000000-0000-0000-0000-000000000000', 'workflow_id_or_name': 'roofit.8', 'parameters': {'input_parameters': {}, 'operational_options': {}}, 'priority': 39}
```

4. Play running more complex workflow like `bsm` to see that priority is different due to different workflow complexity.