### PR TITLE
Mount volume for persistance storage of rabbitmq data

### DIFF
--- a/helm/reana/templates/reana-message-broker.yaml
+++ b/helm/reana/templates/reana-message-broker.yaml
@@ -41,8 +41,15 @@ spec:
           name: tcp
         - containerPort: 15672
           name: management
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/rabbitmq/mnesia
       {{- if .Values.node_label_infrastructure }}
       {{- $full_label := split "=" .Values.node_label_infrastructure }}
       nodeSelector:
         {{ $full_label._0 }}: {{ $full_label._1 }}
       {{- end }}
+      volumes:
+      - name: data
+        hostPath:
+          path: /var/reana/rabbitmq/mnesia

--- a/helm/reana/templates/reana-message-broker.yaml
+++ b/helm/reana/templates/reana-message-broker.yaml
@@ -5,15 +5,24 @@ metadata:
   name: {{ include "reana.prefix" . }}-message-broker
   namespace: {{ .Release.Namespace }}
 spec:
+  type: "NodePort"
   ports:
    - port: 5672
      targetPort: 5672
      name: "tcp"
      protocol: TCP
+  {{- if .Values.debug.enabled }}
+   - port: 31672
+     targetPort: 15672
+     nodePort: 31672
+     name: "management"
+     protocol: TCP
+  {{- else }}
    - port: 15672
      targetPort: 15672
      name: "management"
      protocol: TCP
+  {{- end }}
   selector:
     app: {{ include "reana.prefix" . }}-message-broker
 ---

--- a/reana/reana_dev/cluster.py
+++ b/reana/reana_dev/cluster.py
@@ -114,6 +114,11 @@ def cluster_create(mounts, mode, worker_nodes):  # noqa: D301
                     "hostPort": 32580,
                     "protocol": "TCP",
                 },  # maildev
+                {
+                    "containerPort": 31672,
+                    "hostPort": 31672,
+                    "protocol": "TCP",
+                },  # rabbitmq
             ]
         )
 


### PR DESCRIPTION
closes https://github.com/reanahub/reana/issues/500


Testing Instructions without PR:

1. `max parallel running  workflows helm variable` -> 1
2. Launch n workflows so that some workflows remain in the ready queue.
3. For ex: If n=3, While the 1st is running and 2nd and 3rd are in the queue in `ready state`, kill the queue pod (`message-broker`)
5. The Pod will be restarting again and check `/var/lib/rabbitmq/mnesia`, there will be files with the new name and our previous data is gone.

Testing Instructions with this PR and https://github.com/reanahub/reana-commons/pull/263:

1. `max parallel running  workflows helm variable` -> 1
2. Rebuild the message broker and load the new image.
3. Before killing, using the UI, create a new durable queue and publish a durable message to see if the queue and the message stays after restart.
4. You can also test the without PR case but some message should be in the `ready state`. 
5. Kill the queue pod (`message-broker`)
6. The Pod will be restarting again and check `/var/lib/rabbitmq/mnesia` before and after, there will be files with the same name and our data is persisted.