### PR TITLE
helm: add svc account to status report cronjob

### DIFF
--- a/helm/reana/templates/cronjobs.yaml
+++ b/helm/reana/templates/cronjobs.yaml
@@ -13,6 +13,7 @@ spec:
     spec:
       template:
         spec:
+          serviceAccountName: {{ include "reana.prefixed_infrastructure_svaccount_name" . }}
           containers:
           - name: {{ include "reana.prefix" . }}-system-status
             image: {{ .Values.components.reana_server.image }}


### PR DESCRIPTION
Otherwise it does not have permission to fetch nodes info.

```console
Something went wrong while generating the status report:                                                                      
(403)                                                                                                                         
Reason: Forbidden                                                                                                             
HTTP response headers: HTTPHeaderDict({'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'X-Kubernetes-Pf-Flowschema-Uid': 'c0b0df96-efa1-4474-864d-1a1fefbfbe7a', 'X-Kubernetes-Pf-Prioritylevel
-Uid': 'f8e92979-82ef-48ae-8163-e0ca06a57e60', 'Date': 'Tue, 29 Jun 2021 08:26:03 GMT', 'Content-Length': '277'})             
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"nodes is forbidden: User \"system:serviceaccount:default:default\" cannot list resource \"nodes\" in API group \"\" at the cluster scope","reason":"Forbidd
en","details":{"kind":"nodes"},"code":403}                                                               
```

**To test**:

- Edit values.yaml to enable notifications and get more frequent reports:
```diff
diff --git a/helm/reana/values.yaml b/helm/reana/values.yaml
index 0582fa3..8de2b86 100644
--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -84,9 +84,11 @@ components:
     image: reanahub/reana-message-broker:0.8.0-alpha.1
 
 notifications:
-  enabled: false
-  email_config: {}
-  system_status: "0 0 * * *"
+  enabled: true
+  email_config:
+    sender: admin@reana.io
+    receiver: reana-support@cern.ch
+  system_status: "* * * * *"
 
```
- Optional: Install metrics API if possible. It should work without it installed.
- Without PR: Cronjob should fail, no message in [`MailDev`](http://localhost:32580).
- With PR: Cronjob should work, email status report in [`MailDev`](http://localhost:32580).