### PR TITLE
helm: Kubernetes 1.21

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Version 0.7.4 (UNRELEASED)
     - Adds support for directory download and wildcard patterns to ``download`` command.
     - Adds support for specifying ``kubernetes_memory_limit`` for Kubernetes compute backend jobs.
 - Administrators:
+    - Adds support for Kubernetes 1.21.
     - Adds configuration environment variable to set job memory limits for the Kubernetes compute backend (``REANA_KUBERNETES_JOBS_MEMORY_LIMIT``).
     - Adds configuration environment variable to set maximum custom memory limits that users can assign to their job containers for the Kubernetes compute backend (``REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT``).
     - Fixes Kubernetes job log capture to include information about failures caused by external factors such as OOMKilled.

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
 type: application
 # Chart version.
 version: 0.7.4-alpha.2
-kubeVersion: ">= 1.13.0-0 < 1.21.0-0"
+kubeVersion: ">= 1.13.0-0 < 1.22.0-0"
 dependencies:
   - name: traefik
     version: 1.85.x


### PR DESCRIPTION
Declares support for Kubernetes 1.21 that was successfully tested
locally using Kind 0.11.1.