### PR TITLE
helm: support new paths for workspace directories

### DIFF
--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -50,6 +50,14 @@ spec:
           {{- end }}
           - mountPath: {{ .Values.shared_storage.shared_volume_mount_path }}
             name: reana-shared-volume
+          {{- if .Values.components.reana_workflow_controller.environment.REANA_WORKSPACE_HOSTPATH_MOUNTS }}
+          {{- range  $workspace_paths := split "," .Values.components.reana_workflow_controller.environment.REANA_WORKSPACE_HOSTPATH_MOUNTS }}
+          {{- $workspace_path := split ":" $workspace_paths }}
+          - name: {{ $workspace_path._0 | quote | replace "/" "" }}
+            mountPath: {{ $workspace_path._1 }}
+            mountPropagation: HostToContainer
+          {{- end }}
+          {{- end }}
         env:
           - name: REANA_COMPONENT_PREFIX
             value: {{ include "reana.prefix" . }}
@@ -231,4 +239,12 @@ spec:
       {{- $full_label := split "=" .Values.node_label_infrastructure }}
       nodeSelector:
         {{ $full_label._0 }}: {{ $full_label._1 }}
+      {{- end }}
+      {{- if .Values.components.reana_workflow_controller.environment.REANA_WORKSPACE_HOSTPATH_MOUNTS }}
+      {{- range  $workspace_paths := split "," .Values.components.reana_workflow_controller.environment.REANA_WORKSPACE_HOSTPATH_MOUNTS }}
+      {{- $workspace_path := split ":" $workspace_paths }}
+      - name: {{ $workspace_path._0 | quote | replace "/" "" }}
+        hostPath:
+          path: {{ $workspace_path._0 }}
+      {{- end }}
       {{- end }}

--- a/reana/reana_dev/cluster.py
+++ b/reana/reana_dev/cluster.py
@@ -232,6 +232,13 @@ def cluster_build(
     "cluster_node_path:job_pod_mountpath, e.g /var/reana/mydata:/mydata",
 )
 @click.option(
+    "-w",
+    "--workspace-mounts",
+    multiple=True,
+    help="Which directories from the Kubernetes nodes to mount inside the cluster pods? "
+    "cluster_node_path:job_pod_mountpath, e.g /var/reana/mydata:/mydata",
+)
+@click.option(
     "--mode",
     default="latest",
     callback=validate_mode_option,
@@ -260,6 +267,7 @@ def cluster_build(
 def cluster_deploy(
     namespace,
     job_mounts,
+    workspace_mounts,
     mode,
     values,
     exclude_components,
@@ -308,6 +316,14 @@ def cluster_deploy(
         values_dict.setdefault("components", {}).setdefault(
             "reana_workflow_controller", {}
         ).setdefault("environment", {})["REANA_JOB_HOSTPATH_MOUNTS"] = job_mount_config
+
+    if workspace_mounts:
+        workspace_mounts = ",".join(workspace_mounts)
+        values_dict.setdefault("components", {}).setdefault(
+            "reana_workflow_controller", {}
+        ).setdefault("environment", {})[
+            "REANA_WORKSPACE_HOSTPATH_MOUNTS"
+        ] = workspace_mounts
 
     if mode in ("debug"):
         values_dict.setdefault("debug", {})["enabled"] = True


### PR DESCRIPTION
Temporary solution for a proof of concept to run workflows outside shared path

- Added new `-w (workspace-mounts)` option for `cluster_deploy` command to specify which paths to mount inside reana-workflow-controller, run batches and job pods

Steps to test:
1) Recreate the cluster with latest changes
```
kind delete cluster
reana-dev cluster-create -m /var/reana:/var/reana -m /tmp/reana:/tmp/reana --mode debug 
reana-dev cluster-build --exclude-components=r-ui,r-a-vomsproxy,r-a-krb5 --mode debug
reana-dev cluster-deploy -w /tmp/reana:/tmp/reana --exclude-components=r-a-vomsproxy,r-a-krb5,r-ui --mode debug --admin-email your@email.com --admin-password 123456
```

Note that we specified `-w /tmp/reana:/tmp/reana` in `cluster-deploy`.

2) Change `None` to `/tmp/reana` [here](https://github.com/reanahub/reana-workflow-controller/pull/391/files#diff-c62ab69eb0095073168ae14b880c5b63a61c9f3b2eb8f175df37ed772ba8eaa2R409)

3) Start any workflow

4) Inspect workflow_path:
```
kubectl exec -i -t deployment/reana-db -- psql -U reana -c 'SELECT workspace_path FROM __reana.workflow'
```

Workflows should run successfully in `/var/reana` and `/tmp/reana`:
```
                                            workspace_path
--------------------------------------------------------------------------------------------------

 /tmp/reana/93834493-973a-4080-9d44-70f6fa140c68
 /var/reana/users/00000000-0000-0000-0000-000000000000/workflows/158b6f83-b942-45d2-8657-cf43b6581
2aa
(2 rows)
```