### PR TITLE
git-create-release-commit bumps all available versions in the components

### DIFF
--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -8,10 +8,10 @@
 
 """`reana-dev`'s git commands."""
 
-import datetime
 import os
 import subprocess
 import sys
+from typing import Optional
 
 import click
 
@@ -22,7 +22,6 @@ from reana.config import (
     REPO_LIST_ALL,
     REPO_LIST_SHARED,
 )
-
 from reana.reana_dev.utils import (
     bump_component_version,
     click_add_git_base_branch_option,
@@ -117,8 +116,10 @@ def git_is_current_version_tagged(component):
 
 
 def git_create_release_commit(
-    component, base=GIT_DEFAULT_BASE_BRANCH, next_version=None
-):
+    component: str,
+    base: str = GIT_DEFAULT_BASE_BRANCH,
+    next_version: Optional[str] = None,
+) -> bool:
     """Create a release commit for the given component."""
     if "release:" in get_current_commit(get_srcdir(component)):
         display_message("Nothing to do, last commit is a release commit.", component)
@@ -139,7 +140,7 @@ def git_create_release_commit(
         sys.exit(1)
 
     next_version, modified_files = bump_component_version(
-        component, current_version, next_version=next_version
+        component, next_version=next_version
     )
 
     if (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for reana_dev/utils.py"""
+import pytest
+
+
+class TestTranslatePep440ToSemver2:
+    @pytest.mark.parametrize(
+        "original, expected",
+        [("1.0.0.dev1", "1.0.0-dev.1"), ("0.8.0a2", "0.8.0-alpha.2")],
+    )
+    def test_pep440_to_semver2(self, original: str, expected: str):
+        from reana.reana_dev.utils import translate_pep440_to_semver2
+
+        assert translate_pep440_to_semver2(original) == expected
+
+    @pytest.mark.parametrize(
+        "original", ["0.8.0-alpha.2", "1.0.0-dev.1", "1.0.0-rc.1"],
+    )
+    def test_some_working_semver2_as_input(self, original: str):
+        from reana.reana_dev.utils import translate_pep440_to_semver2
+
+        assert translate_pep440_to_semver2(original) == original
+
+    @pytest.mark.parametrize(
+        "original", ["1.0.0-alpha.beta"],
+    )
+    def test_some_failing_semver2_as_input(self, original: str):
+        from reana.reana_dev.utils import translate_pep440_to_semver2
+
+        with pytest.raises(Exception):
+            translate_pep440_to_semver2(original)
+
+
+class TestParsePep440Version:
+    @pytest.mark.parametrize(
+        "original, expected",
+        [("0.7.0-alpha.1", "0.7.0a1"), ("0.8.0-alpha.2", "0.8.0a2")],
+    )
+    def test_semver2_to_pep440(self, original: str, expected: str):
+        """
+        Underlying package.versioning.Version can handle SemVer2 format
+        """
+        from reana.reana_dev.utils import parse_pep440_version
+
+        assert str(parse_pep440_version(original)) == expected


### PR DESCRIPTION
Closes #516 

Expected behavior:

1. `reana-dev git-create-release-commit -c reana` command will bump all found version files (Helm, Py, JS, OpenAPI) to its next version 

2. `-v` will **enforce the specified version** on all version files (PEP440 will be converted to SemVer2 when needed and vice-versa). 

Behavior examples:

- `reana-dev git-create-release-commit -c reana` will automatically bump Helm (SemVer2) and Python (PEP440). For git tags - SemVer2

- `reana-dev git-create-release-commit -c reana-server` will automatically bump Python and OpenAPI (PEP440). For git tags - PEP440

- `reana-dev git-create-release-commit -c reana -v 0.8.1-alpha.1` will bump Helm to 0.8.1-alpha.1 and Python to 0.8.1a1. For git tags - 0.8.1-alpha.1 (SemVer2)

- `reana-dev git-create-release-commit -c reana-server -v 0.8.1a1` will bump Python to 0.8.1a1. For git tags - 0.8.1a1 (PEP440)


Manual testing: main changes are in `bump_component_version`. In `git_create_release_commit` (`git.py`), comment everything after `bump_component_version` statement. After, in `reana` repo, install update code with `pip install -e .` Run command and check if all version is properly updated.

After the review, I will squash commits into one.