### PR TITLE
helm: explicit number of DB connections

### DIFF
--- a/helm/reana/templates/reana-db.yaml
+++ b/helm/reana/templates/reana-db.yaml
@@ -32,6 +32,9 @@ spec:
       containers:
       - name: db
         image: postgres:9.6.2
+        args:
+        - -c
+        - max_connections=300
         ports:
         - containerPort: 5432
         env:


### PR DESCRIPTION
Enriches `reana-db` helm template to define explicitly the max number
of allowed DB connections. The default value is 100 which may not be
enough for installations launching many concurrent
workflows. Increasing it to 300. Moreover, having the number
explicitly defined in the template will allow site administrators to
easily customise it further.