### PR TITLE
helm: set reana-server API limiter configs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Version 0.8.0 (UNRELEASED)
       (``node_label_runtimebatch``, ``node_label_runtimejobs``, ``node_label_runtimesessions``).
     - Adds a default ``kubernetes_memory_limit`` value (4Gi).
     - Adds configuration environment variable to set workflow scheduling policy (``REANA_WORKFLOW_SCHEDULING_POLICY``).
+    - Adds configuration environment variables to set REST API rate limit values (``REANA_RATELIMIT_GUEST_USER``, ``REANA_RATELIMIT_AUTHENTICATED_USER``).
     - Changes Helm templates to use PostgreSQL 12.8 version.
 
 Version 0.7.4 (2021-07-07)

--- a/helm/reana/README.md
+++ b/helm/reana/README.md
@@ -17,6 +17,8 @@ This Helm automatically prefixes all names using the release name to avoid colli
 | `components.reana_server.environment.REANA_USER_EMAIL_CONFIRMATION` | Enable user to confirm their email address. | true |
 | `components.reana_server.environment.REANA_SCHEDULER_REQUEUE_SLEEP` | Seconds to wait between consuming workflows. | 15 |
 | `components.reana_server.environment.REANA_WORKFLOW_SCHEDULING_POLICY` | Define workflow scheduling strategy. Options are "fifo" for first-in-first-out strategy regardless of users and "balanced" for multi-user-aware scheduling strategy. | "fifo" |
+| `components.reana_server.environment.REANA_RATELIMIT_GUEST_USER` | Set API limiter config for guest users. Users using reana-client will be treated as guests. | "20 per second" |
+| `components.reana_server.environment.REANA_RATELIMIT_AUTHENTICATED_USER` | Set API limiter config for authenticated web UI users. | "20 per second" |
 | `components.reana_server.image`                          | [REANA-Server image](https://hub.docker.com/r/reanahub/reana-server) to use          | `reanahub/reana-server:<chart-release-version>` |
 | `components.reana_server.imagePullPolicy`                | REANA-Server image pull policy                                                       | IfNotPresent                                    |
 | `components.reana_server.uwsgi.processes`                | Number of uWSGI processes                                                            | 6                                               |


### PR DESCRIPTION
closes reanahub/reana-server#404

Merge after https://github.com/reanahub/reana-server/pull/412 (to be able to test)