### PR TITLE
benchmark: improve execution progress plot, add workflow range to analyze

### DIFF
--- a/scripts/reana_bench.py
+++ b/scripts/reana_bench.py
@@ -141,7 +141,7 @@ def _start_workflows_and_record_submit_dates(
     logging.info(f"Starting {workflow_range} workflows...")
     df = pd.DataFrame(columns=["name", "submit_date", "submit_number"])
     submit_number = 0
-    with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         futures = [
             executor.submit(
                 _start_single_workflow, _build_extended_workflow_name(workflow_name, i)


### PR DESCRIPTION
- improves execution progress plot, now using absolute date values instead of relative time values;
- removes _pre_processed_results function as epoch time is not needed anymore for execution progress plot;
- adds "--interval" parameter to "analyze" command to customize execution progress plot datetime axis;
- renames "*_processed_results.csv" to "*_analyzed_results.csv" to align naming with "analyze" command;
- adds new column "workflow_number" in _derive_metrics function in "analyze" to be able to filter data by workflow range, now plots can be generated with subset of workflows only;
- in case of out of bound workflow range, workflows in the range will be included without throwing an error;
- plots files are generated with a suffix that includes workflow range.

addresses #573