### PR TITLE
benchmark: ignore start errors and save started workflows results

### DIFF
--- a/scripts/reana_bench.py
+++ b/scripts/reana_bench.py
@@ -37,7 +37,11 @@ from reana_client.utils import load_reana_spec
 
 urllib3.disable_warnings()
 
-logging.basicConfig(format="%(asctime)s %(message)s", level=logging.WARNING)
+logging.basicConfig(
+    format="%(asctime)s | %(levelname)s | %(message)s",
+    level=logging.WARNING,
+    force=True,
+)
 logger = logging.getLogger("reana-bench")
 logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
closes #584

If during the `start` command, an error happens in the middle we lost started results for previously started workflows. This PR fixes it.

How to test:

Use some fast workflow like `helloworld` demo.

1. Create and upload 3 workflows:

```console
$ ./reana_bench.py submit -w test -n 1-3 
```

2. Start the second workflow: 

```console
$ ./reana_bench.py start -w test -n 2-2  
```

`test_started_results.csv` should look like this:

```csv
name,asked_to_start_date
test-2,2021-11-12T13:02:29
```

3. Collect results of the second workflow:

```console
$ ./reana_bench.py collect -w test -f 
```

Check `test_collected_results.csv`:

```csv
name,run_number,created,started,ended,status,asked_to_start_date,collected_date
test-3,1,2021-11-12T13:02:16,,,created,,2021-11-12T13:05:26
test-2,1,2021-11-12T13:02:16,2021-11-12T13:02:41,2021-11-12T13:02:48,finished,2021-11-12T13:02:29,2021-11-12T13:05:26
test-1,1,2021-11-12T13:02:16,,,created,,2021-11-12T13:05:26
```

`asked_to_start_date` obviously missing, we haven't started workflow `1` and `3` yet.

4. Start workflow 1-3:

```console
$ ./reana_bench.py start -w test -n 1-3
2021-11-12 14:08:26,140 | INFO | Starting (1, 3) workflows...
2021-11-12 14:08:26,349 | ERROR | Workflow test-2 failed during the start. Details: Workflow test-2.1 is already finished and cannot be started again.
2021-11-12 14:08:26,397 | INFO | Loading existing started results. Appending...
2021-11-12 14:08:26,400 | INFO | Saving started results...
2021-11-12 14:08:26,402 | INFO | Finished starting workflows.
```

There is one error - workflow 2 already started. But we managed to start workflows 1 and 3.
Check `test_started_results.csv`, it should contain `asked_to_start_date` for workflow 1 and 3:

```csv
name,asked_to_start_date
test-2,2021-11-12T13:02:29
test-1,2021-11-12T13:08:26
test-3,2021-11-12T13:08:26
```


