### PR TITLE
benchmark: harmonize colours between plots

### DIFF
--- a/reana/reana_benchmark/config.py
+++ b/reana/reana_benchmark/config.py
@@ -7,6 +7,7 @@
 """Defines values shared between reana-benchmark modules."""
 
 import os
+from enum import Enum
 
 REANA_ACCESS_TOKEN = os.getenv("REANA_ACCESS_TOKEN")
 
@@ -15,3 +16,18 @@ WORKERS_DEFAULT_COUNT = 1
 
 # common datetime format
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+
+class WorkflowStatus(str, Enum):
+    """Enumeration of workflow statuses.
+
+    Example:
+        WorkflowStatus.failed == "failed"  # True
+    """
+
+    created = "created"
+    queued = "queued"
+    pending = "pending"
+    running = "running"
+    failed = "failed"
+    finished = "finished"


### PR DESCRIPTION
- adds point to indicate whatever workflow finished or failed in execution_progress plot;
- use the same colours in execution_status and execution_progress plots;
- histogram plots have only one label so colours harmonization is not applied there, colours are generated automatically, usually blue.

closes #588 

How to test:

1. If you don't have already collected results from previous benchmarks you can get new ones:

```console
$ reana-benchmark launch -w color -n 1-10
$ reana-benchmark collect -w color
```

OR, you can use this CSV content and save it under `color_collected_results.csv`:

```csv
name,run_number,created,started,ended,status,asked_to_start_date,collected_date
color-3,1,2021-11-16T10:24:12,2021-11-16T10:24:39,,running,2021-11-16T10:24:23,2021-11-16T10:24:47
color-2,1,2021-11-16T10:24:11,2021-11-16T10:24:37,2021-11-16T10:24:44,finished,2021-11-16T10:24:23,2021-11-16T10:24:47
color-1,1,2021-11-16T10:24:11,2021-11-16T10:24:35,2021-11-16T10:24:42,failed,2021-11-16T10:24:23,2021-11-16T10:24:47
color-4,1,2021-11-16T10:24:12,,,queued,2021-11-16T10:24:23,2021-11-16T10:24:47
```

You can even modify this CSV file. Few notes if you decided to modify content for testing:

- `running` status doesn't have `ended` value;
- `pending` and `queued` statuses doesn't have `started` and `ended` values;
- `collected_date` is the same for all workflows.

2. Run `reana-benchmark analyze -w color -n 1-10` to get plots.

3. This PR is modifying the style and colors of the two plots so you can check if colors/labels make sense to you, etc.