### PR TITLE
benchmark: add datetime range plot parameter to analyze command

### DIFF
--- a/reana/reana_benchmark/analyze.py
+++ b/reana/reana_benchmark/analyze.py
@@ -110,9 +110,10 @@ def _build_plots(df: pd.DataFrame, plot_parameters: Dict) -> List[Tuple[str, Fig
 
 def _build_execution_progress_plot(
     df: pd.DataFrame, plot_parameters: Dict
-) -> (str, Figure):
+) -> Tuple[str, Figure]:
     title = plot_parameters["title"]
     interval = plot_parameters["time_interval"]
+    datetime_range = plot_parameters.get("datetime_range")
 
     fig, ax = plt.subplots(figsize=(8, 4), dpi=200, constrained_layout=True)
 
@@ -221,6 +222,11 @@ def _build_execution_progress_plot(
 
     ax.set_ylim(ymin=df["workflow_number"].min() - 1)
 
+    if datetime_range:
+        left = datetime.strptime(datetime_range[0], DATETIME_FORMAT)
+        right = datetime.strptime(datetime_range[1], DATETIME_FORMAT)
+        ax.set_xlim(left=left, right=right)
+
     ax.grid(color="black", linestyle="--", alpha=0.15)
 
     def _build_legend(axes):
@@ -252,7 +258,7 @@ def _build_execution_progress_plot(
 
 def _build_execution_status_plot(
     df: pd.DataFrame, plot_parameters: Dict
-) -> (str, Figure):
+) -> Tuple[str, Figure]:
     title = plot_parameters["title"]
     total = len(df)
     statuses = list(df["status"].unique())
@@ -279,7 +285,7 @@ def _build_execution_status_plot(
     return "execution_status", fig
 
 
-def _max_min_mean_median(series: pd.Series) -> (int, int, int, int):
+def _max_min_mean_median(series: pd.Series) -> Tuple[int, int, int, int]:
     max_value = series.max()
     min_value = series.min()
     mean_value = series.mean()
@@ -336,7 +342,7 @@ def _build_pending_time_histogram(
 
 
 def _save_plots(
-    plots: List[Tuple[str, Figure]], workflow: str, workflow_range: (int, int)
+    plots: List[Tuple[str, Figure]], workflow: str, workflow_range: Tuple[int, int]
 ) -> None:
     logger.info("Saving plots...")
     for base_name, figure in plots:
@@ -347,7 +353,7 @@ def _save_plots(
 
 
 def analyze(
-    workflow_prefix: str, workflow_range: (int, int), plot_params: Dict
+    workflow_prefix: str, workflow_range: Tuple[int, int], plot_params: Dict
 ) -> None:  # noqa: D103
     results_path = build_collected_results_path(workflow_prefix)
     collected_results = pd.read_csv(results_path)

--- a/reana/reana_benchmark/config.py
+++ b/reana/reana_benchmark/config.py
@@ -31,3 +31,9 @@ class WorkflowStatus(str, Enum):
     running = "running"
     failed = "failed"
     finished = "finished"
+
+
+# position in a string of a "-" separator in datetime range
+DATETIME_RANGE_SEPARATOR_POSITION = 19
+
+DATETIME_RANGE_LENGTH = 19 * 2 + 1

--- a/reana/reana_benchmark/utils.py
+++ b/reana/reana_benchmark/utils.py
@@ -15,6 +15,16 @@ logger = logging.getLogger("reana-benchmark")
 logger.setLevel(logging.INFO)
 
 
+def validate_date(date_text: str) -> None:
+    """Validate datetime string against common reana-benchmark datetime format."""
+    try:
+        datetime.strptime(date_text, DATETIME_FORMAT)
+    except ValueError:
+        raise ValueError(
+            f'"{date_text}" has incorrect datetime format, correct format is "{DATETIME_FORMAT}".'
+        )
+
+
 def get_utc_now_timestamp() -> str:  # noqa: D103
     return datetime.utcnow().strftime(DATETIME_FORMAT)
 


### PR DESCRIPTION
Adding `datetime_range` option to `analyze` command to be able to "zoom" into the `execution_progress` plot. The new option is similar to the `interval` option we already have, it acts as a customizer to a plot.

closes #583

How to test:

1. Save dummy CSV file as `datetime-range_collected_results.csv`:

```csv
name,run_number,created,started,ended,status,asked_to_start_date,collected_date
color-3,1,2021-11-16T10:24:12,2021-11-16T10:24:39,,running,2021-11-16T10:24:23,2021-11-16T10:25:47
color-2,1,2021-11-16T10:24:11,2021-11-16T10:24:37,2021-11-16T10:25:44,finished,2021-11-16T10:24:23,2021-11-16T10:25:47
color-1,1,2021-11-16T10:24:11,2021-11-16T10:24:35,2021-11-16T10:25:42,failed,2021-11-16T10:24:23,2021-11-16T10:25:47
color-4,1,2021-11-16T10:24:12,,,queued,2021-11-16T10:24:23,2021-11-16T10:25:47
color-5,1,2021-11-16T10:24:12,,,pending,2021-11-16T10:24:23,2021-11-16T10:25:47
color-12,1,2021-11-16T10:24:11,2021-11-16T10:24:37,2021-11-16T10:25:44,finished,2021-11-16T10:24:23,2021-11-16T10:25:47
color-13,1,2021-11-16T10:24:11,2021-11-16T10:24:37,2021-11-16T10:25:44,finished,2021-11-16T10:24:23,2021-11-16T10:25:47
```

You can also edit the while (follow the first point from [here](https://github.com/reanahub/reana/pull/592))

2. Produce plot without changes: `reana-benchmark analyze -w datetime-range -n 1-20`. Check execution progress plot. This is an unmodified plot.

3. Use new `datetime` option, e.g run `reana-benchmark analyze -w datetime-range -n 1-20 --datetime 2021-11-16T10:24:35-2021-11-16T10:25:35`. You need to follow the datetime format. Check execution progress plot, now the timeline (x-axis) is only focused on the datetime range you specified.