### PR TITLE
benchmark: approximate x-axis interval for execution progress plot

### DIFF
--- a/reana/reana_benchmark/analyze.py
+++ b/reana/reana_benchmark/analyze.py
@@ -112,7 +112,6 @@ def _build_execution_progress_plot(
     df: pd.DataFrame, plot_parameters: Dict
 ) -> Tuple[str, Figure]:
     title = plot_parameters["title"]
-    interval = plot_parameters["time_interval"]
     datetime_range = plot_parameters.get("datetime_range")
 
     fig, ax = plt.subplots(figsize=(8, 4), dpi=200, constrained_layout=True)
@@ -211,7 +210,10 @@ def _build_execution_progress_plot(
     # force integers on y axis
     ax.yaxis.set_major_locator(MaxNLocator(integer=True))
 
-    ax.xaxis.set_major_locator(mdates.MinuteLocator(interval=interval))
+    interval = plot_parameters.get("time_interval")
+    if interval:
+        ax.xaxis.set_major_locator(mdates.SecondLocator(interval=interval))
+
     ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M:%S"))
 
     # rotate dates on x axis

--- a/reana/reana_benchmark/cli.py
+++ b/reana/reana_benchmark/cli.py
@@ -8,7 +8,7 @@
 """Combines reana-benchmark modules into CLI commands."""
 
 import logging
-from typing import NoReturn, Tuple, Optional, Union
+from typing import NoReturn, Optional, Tuple, Union
 
 import click
 import urllib3
@@ -221,16 +221,15 @@ def launch(
 @click.option(
     "--interval",
     "-i",
-    help="Ticks interval in minutes for execution progress plot [default=10]",
+    help="Ticks interval in seconds for execution progress plot",
     type=int,
-    default=10,
 )
 def analyze_command(
     workflow: str,
     workflow_range: Tuple[int, int],
     datetime_range: Tuple[str, str],
     title: str,
-    interval: int,
+    interval: Optional[int],
 ) -> NoReturn:
     """Produce plots based on workflows results collected before."""
     plot_params = {


### PR DESCRIPTION
- in addition, add one more tick on x-axis if interval is approximated to ensure that all points are covered;
- change time interval from minutes to seconds.

closes #590

How to test:

1. If you don't have already collected results from previous benchmarks you can get new ones:

```console
$ reana-benchmark launch -w time -n 1-10
$ reana-benchmark collect -w time
```

OR, you can use this CSV content and save it under `time_collected_results.csv`:

```csv
name,run_number,created,started,ended,status,asked_to_start_date,collected_date
time-3,1,2021-11-16T10:24:12,2021-11-16T10:24:39,,running,2021-11-16T10:24:23,2021-11-16T10:24:47
time-2,1,2021-11-16T10:24:11,2021-11-16T10:24:37,2021-11-16T10:24:44,finished,2021-11-16T10:24:23,2021-11-16T10:24:47
time-1,1,2021-11-16T10:24:11,2021-11-16T10:24:35,2021-11-16T10:24:42,failed,2021-11-16T10:24:23,2021-11-16T10:24:47
time-4,1,2021-11-16T10:24:12,,,queued,2021-11-16T10:24:23,2021-11-16T10:24:47
```

You can even modify this CSV file. Few notes if you decided to modify content for testing:

- `running` status doesn't have `ended` value;
- `pending` and `queued` statuses doesn't have `started` and `ended` values;
- `collected_date` is the same for all workflows.

2. Run `reana-benchmark analyze -w time -n 1-10` to get plots.

3. This PR modifies x-axis ticks interval in the `execution_progress` plot. You can take a look if ticks make sense with various date lengths.

4. Add `-i` (time interval option) to check if new updates didn't break the option. Run `reana-benchmark analyze -w time -n 1-10 -i 5`