### PR TITLE
helm: make http logging configurable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Version 0.8.1 (UNRELEASED)
+--------------------------
+
+- Administrators:
+    - Adds new configuration option ``reana_server.uwsgi.log_all`` to toggle the logging of all the HTTP requests.
+    - Adds new configuration options ``reana_server.uwsgi.log_4xx`` and ``reana_server.uwsgi.log_5xx`` to only log HTTP error requests, i.e. HTTP requests with status code 4XX and 5XX. To make this configuration effective ``reana_server.uwsgi.log_all`` must be ``false``.
+    - Changes uWSGI configuration to log all HTTP requests in REANA-Server by default.
+
 Version 0.8.0 (2021-11-30)
 --------------------------
 

--- a/helm/reana/README.md
+++ b/helm/reana/README.md
@@ -23,6 +23,9 @@ This Helm automatically prefixes all names using the release name to avoid colli
 | `components.reana_server.imagePullPolicy`                | REANA-Server image pull policy                                                       | IfNotPresent                                    |
 | `components.reana_server.uwsgi.processes`                | Number of uWSGI processes                                                            | 6                                               |
 | `components.reana_server.uwsgi.threads`                  | Number of uWSGI threads                                                              | 4                                               |
+| `components.reana_server.uwsgi.log_all`                  | Log all HTTP requests                                                                | true                                            |
+| `components.reana_server.uwsgi.log_4xx`                  | Log only error HTTP requests with status code 4xx. To make this configuration effective `components.reana_server.uwsgi.log_all` must be false. | true |
+| `components.reana_server.uwsgi.log_5xx`                  | Log only error HTTP requests with status code 5xx. To make this configuration effective `components.reana_server.uwsgi.log_all` must be false. | true |
 | `components.reana_ui.announcement`                       | Announcement message displayed in site top banner                                    | None                                            |
 | `components.reana_ui.enabled`                            | Instantiate the [REANA-UI](https://github.com/reanahub/reana-ui)                     | true                                            |
 | `components.reana_ui.image`                              | [REANA-UI image](https://hub.docker.com/r/reanahub/reana-ui) to use                  | `reanahub/reana-ui:<chart-release-version>`     |

--- a/helm/reana/templates/uwsgi-config.yaml
+++ b/helm/reana/templates/uwsgi-config.yaml
@@ -25,9 +25,11 @@ data:
                           # https://uwsgi-docs.readthedocs.io/en/latest/articles/SerializingAccept.html
 
     # Logging
+    {{- if not .Values.components.reana_server.uwsgi.log_all }}
     disable-logging = true
-    log-4xx = true
-    log-5xx = true
+    log-4xx = {{ .Values.components.reana_server.uwsgi.log_4xx }}
+    log-5xx = {{ .Values.components.reana_server.uwsgi.log_5xx }}
+    {{- end }}
 
     # Workers management
     max-requests = 1999

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -72,6 +72,9 @@ components:
     uwsgi:
       processes: 6
       threads: 4
+      log_all: true
+      log_4xx: true
+      log_5xx: true
   reana_workflow_controller:
     imagePullPolicy: IfNotPresent
     image: reanahub/reana-workflow-controller:0.8.0


### PR DESCRIPTION
- by default, log all HTTP requests
- allow logging only HTTP error requests (status code 4xx and 5xx)

closes reanahub/reana-server#417


#### To test:
- Force uWSGI (Production mode):
```diff
diff --git a/helm/reana/templates/reana-server.yaml b/helm/reana/templates/reana-server.yaml
index ab43b8b..6be9538 100644
--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -37,7 +37,7 @@ spec:
         ports:
         - containerPort: 5000
           name: http
-        {{- if .Values.debug.enabled }}
+        {{- if false }}
         command: ["/bin/sh", "-c"]
         args: ["invenio run -h 0.0.0.0 -p 5000"]
         tty: true
```
- Play with different configurations and verify that logs are properly displayed
- To force 4xx, just navigate to /api/foo (`curl -k https://localhost:30443/api/foo`)
- To force 5xx, you can raise an Exception in one of the API endpoints.