### PR TITLE
helm: relax rate limiter value for local developments

### DIFF
--- a/helm/configurations/values-dev.yaml
+++ b/helm/configurations/values-dev.yaml
@@ -5,6 +5,7 @@ components:
       image: reanahub/reana-server
       environment:
         REANA_SCHEDULER_REQUEUE_SLEEP: 2
+        REANA_RATELIMIT_SLOW: "5 per second"
     reana_workflow_controller:
       image: reanahub/reana-workflow-controller
       environment:


### PR DESCRIPTION
Issue as described by @mdonadoni : 
`for each launch request  two requests are actually done (OPTIONS followed by POST) and both of them count towards the rate limit. Given that the limit is "1/5 second", the POST request is always blocked and returns an error`
This PR modifies the rate limiter value to be more permissive for local developments