### PR TITLE
cli: fix upper-bound in `git-upgrade-shared-modules`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Version 0.9.0 (UNRELEASED)
     - Adds configuration environment variable ``reana_server.environment.REANA_WORKFLOW_SCHEDULING_READINESS_CHECK_LEVEL`` to define checks that are performed to assess whether the cluster is ready to start new workflows.
     - Changes default consumer prefetch count to handle 10 messages instead of 200 in order to reduce the probability of 406 PRECONDITION errors on message acknowledgement.
     - Changes configuration option ``quota.workflow_termination_update_policy`` to deactivate workflow termination accounting by default.
+- Developers:
+    - Changes `git-upgrade-shared-modules` to generate the correct upper-bound in `setup.py`.
 
 Version 0.8.2 (UNRELEASED)
 --------------------------

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021 CERN.
+# Copyright (C) 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -480,13 +480,7 @@ def update_module_in_cluster_components(
             sys.exit(1)
 
         new_version_obj = Version(new_version)
-        next_minor_version = ".".join(
-            [
-                str(new_version_obj.major),
-                str(new_version_obj.minor + 1),
-                str(new_version_obj.micro),
-            ]
-        )
+        next_minor_version = f"{new_version_obj.major}.{new_version_obj.minor + 1}.0"
         replace_string(
             file_="setup.py",
             find='>=.*,<.*[^",]',


### PR DESCRIPTION
Closes #613

How to test:
1. Patch `fetch_latest_pypi_version` in [utils.py](https://github.com/reanahub/reana/blob/4a212c7f5be37e63a98db8984f2df898c060c0bd/reana/reana_dev/utils.py#L378) to return a custom version number:
```diff
def fetch_latest_pypi_version(package):
     """Fetch latest released version of a package."""
     import requests
 
+    if package == "reana-commons":
+        return "0.10.3"
+
     pypi_rc_info = requests.get("https://pypi.python.org/pypi/{}/json".format(package))
     return sorted(pypi_rc_info.json()["releases"].keys(), key=Version)[-1]
```
2. Run `reana-dev git-upgrade-shared-modules -c . --use-latest-known-tag` in one of the components, e.g. reana-server

Expected result: In `setup.py` the upper-bound is set to `0.11.0`
```diff
-    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.9.0a6,<0.10.0",
+    "reana-commons[kubernetes,yadage,snakemake,cwl]>=0.10.3,<0.11.0",
```