### PR TITLE
helm: Kubernetes 1.24

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Version 0.9.0 (UNRELEASED)
 --------------------------
 
 - Administrators:
-    - Adds support for Kubernetes version 1.22 and 1.23 clusters.
+    - Adds support for Kubernetes clusters 1.22, 1.23, 1.24.
     - Removes support for Kubernetes version prior to 1.19.
     - Adds configuration environment variable ``reana_server.environment.REANA_RATELIMIT_SLOW`` to limit API requests to some protected endpoints e.g launch workflow.
     - Adds configuration environment variable ``reana_server.environment.REANA_WORKFLOW_SCHEDULING_READINESS_CHECK_LEVEL`` to define checks that are performed to assess whether the cluster is ready to start new workflows.

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
 type: application
 # Chart version.
 version: 0.9.0-alpha.5
-kubeVersion: ">= 1.19.0-0 < 1.24.0-0"
+kubeVersion: ">= 1.19.0-0 < 1.25.0-0"
 dependencies:
   - name: traefik
     version: 10.3.4


### PR DESCRIPTION
Declares support for Kubernetes 1.24 that was successfully tested
locally using Kind 0.14.