### PR TITLE
Pin K8s version in Kind config

### DIFF
--- a/etc/kind-localhost-30443.yaml
+++ b/etc/kind-localhost-30443.yaml
@@ -12,3 +12,4 @@ nodes:
           kubeletExtraArgs:
             node-labels: "ingress-ready=true"
     role: control-plane
+    image: kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207


### PR DESCRIPTION
The Helm chart of v0.8 requires K8s <1.22.0 which will break with the most recent version of kindest/node.

References: https://github.com/reanahub/reana/blob/ed48d7eedf92ff64683a2436c890aa49df70f056/helm/reana/Chart.yaml#L31