### PR TITLE
ci: define GHA reusable workflows

### DIFF
--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -1,0 +1,20 @@
+# This file is part of REANA.
+# Copyright (C) 2020, 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+name: Docker build
+
+on:
+  workflow_call:
+
+jobs:
+
+  docker-build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "🏗️ Build Docker image"
+        run: ./run-tests.sh --check-docker-build

--- a/.github/workflows/ci-docker-lint.yml
+++ b/.github/workflows/ci-docker-lint.yml
@@ -1,0 +1,20 @@
+# This file is part of REANA.
+# Copyright (C) 2020, 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+name: Docker lint
+
+on:
+  workflow_call:
+
+jobs:
+
+  docker-lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "🔍 Check Dockerfile compliance"
+        run: ./run-tests.sh --check-dockerfile

--- a/.github/workflows/ci-node-lint.yml
+++ b/.github/workflows/ci-node-lint.yml
@@ -1,0 +1,46 @@
+# This file is part of REANA.
+# Copyright (C) 2020, 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+name: Node lint
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node version to install"
+        default: "16"
+        required: false
+        type: string
+
+jobs:
+
+  node-lint-prettier:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "⚡ Setup Node"
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: "⚡ Install Javascript dependencies"
+        run: yarn global add prettier
+      - name: "🔍 Check Javascript code formatting"
+        run: ./run-tests.sh --check-prettier
+
+  node-lint-eslint:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "⚡ Setup Node"
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: "⚡ Install Javascript dependencies"
+        run: yarn global add eslint
+      - name: "🔍 Check Javascript code formatting"
+        run: ./run-tests.sh --check-lint

--- a/.github/workflows/ci-node-test.yml
+++ b/.github/workflows/ci-node-test.yml
@@ -1,0 +1,32 @@
+# This file is part of REANA.
+# Copyright (C) 2020, 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+name: Node test
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: "Node version to install"
+        default: "16"
+        required: false
+        type: string
+
+jobs:
+
+  node-test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "⚡ Setup Node"
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: "⚡ Install Javascript dependencies"
+        run: yarn
+      - name: "⚙️ Run Javascript tests"
+        run: ./run-tests.sh --check-js-tests

--- a/.github/workflows/ci-python-lint.yml
+++ b/.github/workflows/ci-python-lint.yml
@@ -1,0 +1,78 @@
+# This file is part of REANA.
+# Copyright (C) 2020, 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+name: Python lint
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to install"
+        default: "3.8"
+        required: false
+        type: string
+
+jobs:
+
+  python-lint-black:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "🐍 Setup Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: "🔍 Check Python code formatting"
+        run: |
+          pip install --upgrade pip
+          pip install black
+          ./run-tests.sh --check-black
+
+  python-lint-flake8:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "🐍 Setup Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: "🔍 Check compliance with pep8, pyflakes and circular complexity"
+        run: |
+          pip install --upgrade pip
+          pip install flake8
+          ./run-tests.sh --check-flake8
+
+  python-lint-pydocstyle:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "🐍 Setup Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: "🔍 Check compliance with Python docstring conventions"
+        run: |
+          pip install --upgrade pip
+          pip install pydocstyle
+          ./run-tests.sh --check-pydocstyle
+
+  python-lint-manifest:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "🐍 Setup Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: "🔍 Check Python manifest completeness"
+        run: |
+          pip install --upgrade pip
+          pip install check-manifest
+          ./run-tests.sh --check-manifest

--- a/.github/workflows/ci-python-test.yml
+++ b/.github/workflows/ci-python-test.yml
@@ -1,0 +1,47 @@
+# This file is part of REANA.
+# Copyright (C) 2020, 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+name: Python test
+
+on:
+  workflow_call:
+    inputs:
+      python-versions:
+        description: "Array of Python versions"
+        default: "['3.8']"
+        required: false
+        type: string
+    secrets:
+      codecov-token:
+        required: true
+
+jobs:
+
+  python-test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ${{ fromJSON(inputs.python-versions) }}
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "🐍 Setup Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: "🐍 Install Python dependencies"
+        run: |
+          pip install --upgrade pip setuptools py
+          pip install twine wheel
+          pip install .[all]
+      - name: "⚙️ Run pytest"
+        run: ./run-tests.sh --check-pytest
+      - name: "☂️ Codecov Coverage"
+        uses: codecov/codecov-action@v3
+        if: ${{ matrix.python-version == fromJSON(inputs.python-versions)[0] }}
+        with:
+          token: ${{ secrets.codecov-token }}
+          files: coverage.xml

--- a/.github/workflows/ci-shell-lint.yml
+++ b/.github/workflows/ci-shell-lint.yml
@@ -1,0 +1,22 @@
+# This file is part of REANA.
+# Copyright (C) 2020, 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+name: Shell lint
+
+on:
+  workflow_call:
+
+jobs:
+
+  shell-lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "⚙️ Runs shell script static analysis"
+        run: |
+          sudo apt-get install shellcheck
+          ./run-tests.sh --check-shellscript

--- a/.github/workflows/ci-sphinx-docs.yml
+++ b/.github/workflows/ci-sphinx-docs.yml
@@ -1,0 +1,53 @@
+# This file is part of REANA.
+# Copyright (C) 2020, 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+name: Sphinx docs
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to install"
+        default: "3.8"
+        required: false
+        type: string
+      install-graphviz:
+        description: "Whether to install graph packages"
+        required: true
+        type: boolean
+      install-libcurl:
+        description: "Whether to install curl packages"
+        required: true
+        type: boolean
+
+jobs:
+
+  sphinx-docs:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "⏬ Checkout"
+        uses: actions/checkout@v3
+      - name: "🐍 Setup Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: "💻 Install system dependencies (graphviz)"
+        if: ${{ inputs.install-graphviz }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install python3-dev graphviz libgraphviz-dev pkg-config
+      - name: "💻 Install system dependencies (libcurl)"
+        if: ${{ inputs.install-libcurl }}
+        run: |
+          sudo apt-get update -y
+          sudo apt install libcurl4-openssl-dev libssl-dev
+          sudo apt-get install libgnutls28-dev
+      - name: "🐍 Install Python dependencies"
+        run: |
+          pip install --upgrade pip setuptools py
+          pip install -r docs/requirements.txt
+      - name: "⚙️ Run Sphinx documentation with doctests"
+        run: ./run-tests.sh --check-sphinx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,140 +9,26 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  lint-shellcheck:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+  shell-lint:
+    uses: ./.github/workflows/ci-shell-lint.yml@master
 
-      - name: Runs shell script static analysis
-        run: |
-          sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellscript
+  python-lint:
+    uses: ./.github/workflows/ci-python-lint.yml@master
 
-  lint-black:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+  sphinx-docs:
+    uses: ./.github/workflows/ci-sphinx-docs.yml@master
+    with:
+      install-graphviz: true
+      install-libcurl: false
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+  python-test:
+    uses: ./.github/workflows/ci-python-test.yml@master
+    with:
+      python-versions: "['3.6', '3.7', '3.8', '3.9']"
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Check Python code formatting
-        run: |
-          pip install black
-          ./run-tests.sh --check-black
-
-  lint-flake8:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Check compliance with pep8, pyflakes and circular complexity
-        run: |
-          pip install --upgrade pip
-          pip install flake8
-          ./run-tests.sh --check-flake8
-
-  lint-pydocstyle:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Check compliance with Python docstring conventions
-        run: |
-          pip install pydocstyle
-          ./run-tests.sh --check-pydocstyle
-
-  lint-check-manifest:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Check Python manifest completeness
-        run: |
-          pip install check-manifest
-          ./run-tests.sh --check-manifest
-
-  docs-sphinx:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt install libcurl4-openssl-dev libssl-dev
-          sudo apt-get install libgnutls28-dev
-
-      - name: Install Python dependencies
-        run: |
-          pip install --upgrade pip setuptools py
-          pip install -e .[all]
-
-      - name: Run Sphinx documentation with doctests
-        run: ./run-tests.sh --check-sphinx
-
-  python-tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-    env:
-      VIRTUAL_ENV: "test"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Python dependencies
-        run: |
-          pip install --upgrade pip setuptools py
-          pip install twine wheel
-          pip install -e .[all]
-
-      - name: Run pytest
-        run: ./run-tests.sh --check-pytest
-
-      - name: Codecov Coverage
-        if: matrix.python-version == 3.8
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-
-  lint-helm:
+  helm-lint:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR is a first approximation to the idea proposed in issue https://github.com/reanahub/reana/issues/665.

As of **today**, GitHub does not support defining GHA reusable workflows outside of the `.github/workflows` directory ([reference](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow)), so the proposal is to define them in this repo (which serves as some sort of _"hub"_), and have most of the REANA repositories pointing their `ci.yml` workflows to them. As an example, the `ci.yml` workflow of this same repository has been rewritten to make use of this functionality.

The reusable workflow _steps_ have been defined considering the smallest set of common steps across repositories, so most of Python / JS workflows can be substituted. However, trouble is anticipated in the following cases:

- `reana-client` (because of its very [custom set of testing steps](https://github.com/reanahub/reana-client/blob/e1971cac6bb039053037c1be9e2c0958eb7e0558/.github/workflows/ci.yml#L141-L208)).
- `reana-server` (for its [generation of OpenAPI spec](https://github.com/reanahub/reana-server/blob/2e58f892bbb57314a87c372a8bacb1ef796d473a/.github/workflows/ci.yml#L127-L128) when testing).
- `reana-job-controller` (for its [custom installation of dependencies](https://github.com/reanahub/reana-job-controller/blob/6d051257edcabfe1ffed4ddb74d102b2948203fa/.github/workflows/ci.yml#L132-L137) when testing).
- `reana-workflow-controller` (for its [generation of OpenAPI spec](https://github.com/reanahub/reana-workflow-controller/blob/9ccc3a93834f3b85799c9fb7f64e7030e9c5757d/.github/workflows/ci.yml#L133-L134) when testing).
- `reana-workflow-engine-yadage` (for its [pinning of setuptools<56](https://github.com/reanahub/reana-workflow-engine-yadage/blob/df242868ed7dcf03fa358040109842e3d23c3be0/.github/workflows/ci.yml#L133) when testing).

---

Feel free to change names / descriptions at will. This is just a proposal.