### PR TITLE
helm: Kubernetes 1.25

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Version 0.9.0 (UNRELEASED)
 
 - Administrators:
     - Adds "infinity" option to ``REANA_SCHEDULER_REQUEUE_COUNT`` to disable requeue count.
-    - Adds support for Kubernetes clusters 1.22, 1.23, 1.24.
+    - Adds support for Kubernetes clusters 1.22, 1.23, 1.24, 1.25.
     - Removes support for Kubernetes version prior to 1.19.
     - Adds new configuration option ``workspaces.retention_rules.maximum_period`` to set a default period for workspace retention rules.
     - Adds new configuration option ``workspaces.retention_rules.cronjob_schedule`` to set how often pending retention rules should be applied.

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
 type: application
 # Chart version.
 version: 0.9.0-alpha.5
-kubeVersion: ">= 1.19.0-0 < 1.25.0-0"
+kubeVersion: ">= 1.19.0-0 < 1.26.0-0"
 dependencies:
   - name: traefik
     version: 10.3.4


### PR DESCRIPTION
Declares support for Kubernetes 1.25 that was successfully tested locally using Kind 0.15.