### PR TITLE
config: add reana-client-go to CLIENT repositories

### DIFF
--- a/reana/config.py
+++ b/reana/config.py
@@ -72,6 +72,7 @@ REPO_LIST_CLIENT = [
     "reana-db",
     # client
     "reana-client",
+    "reana-client-go",
 ]
 """List of git repositories related to command line clients."""
 

--- a/reana/reana_dev/client.py
+++ b/reana/reana_dev/client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -30,7 +30,7 @@ def client_install():  # noqa: D301
     """Install latest REANA client and its dependencies."""
     for component in REPO_LIST_CLIENT:
         for cmd in [
-            "pip install . --upgrade",
+            "if [ -e setup.py ]; then pip install . --upgrade; fi",
         ]:
             run_command(cmd, component)
     run_command("pip check", "reana")


### PR DESCRIPTION
Useful for commands such as `reana-dev git-fetch -c CLIENT` etc.

Modifies `reana-dev client-install` accordingly.