### PR TITLE
uwsgi: enable keep-alive support

### DIFF
--- a/helm/reana/templates/uwsgi-config.yaml
+++ b/helm/reana/templates/uwsgi-config.yaml
@@ -8,7 +8,7 @@ data:
   uwsgi.ini: |
     [uwsgi]
     stats = /tmp/stats.socket
-    http-socket = 0.0.0.0:5000
+    http = 0.0.0.0:5000
     module = invenio_app.wsgi:application
     master = true
     processes = {{ .Values.components.reana_server.uwsgi.processes }}
@@ -41,3 +41,6 @@ data:
     die-on-term = true
     hook-master-start = unix_signal:2 gracefully_kill_them_all
     hook-master-start = unix_signal:15 gracefully_kill_them_all
+
+    # enable keepalive to avoid 500/502 from traefik
+    http-keepalive = 1


### PR DESCRIPTION
Enable support for keep-alive in uWSGI's configuration. This fixes an
issue with Traefik sporadically returning 500 or 502 status codes, with
logs reporting errors such as `http: server closed idle connection` and
`write: broken pipe`.

See
https://uwsgi-docs.readthedocs.io/en/latest/HTTP.html#http-keep-alive
for more information about keep-alive in uWSGI.


How to test:
1. Create a new workflow: `reana-client create -w workflow`
2. Run many concurrent uploads: ``for i in `seq 50`; do reana-client upload -w workflow.1 &; done; wait``