### PR TITLE
helm: Kubernetes 1.26

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 0.9.1 (UNRELEASED)
 - Administrators:
     - Adds new configuration option ``interactive_sessions.maximum_inactivity_period`` to set a limit in days for the maximum inactivity period of interactive sessions after which they will be closed.
     - Adds new configuration option ``interactive_sessions.cronjob_schedule`` to set how often interactive session cleanup should be performed.
+    - Adds support for Kubernetes clusters 1.26.
 
 Version 0.9.0 (2023-01-26)
 --------------------------

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "reana"
-copyright = "2017-2020 info@reana.io"
+copyright = "2017-2023 info@reana.io"
 author = "info@reana.io"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
 type: application
 # Chart version.
 version: 0.9.0
-kubeVersion: ">= 1.19.0-0 < 1.26.0-0"
+kubeVersion: ">= 1.19.0-0 < 1.27.0-0"
 dependencies:
   - name: traefik
     version: 10.3.4


### PR DESCRIPTION
Declares support for Kubernetes 1.26 that was successfully tested locally using Kind 0.17 with the image
`kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352`.