### PR TITLE
uwsgi: fix memory consumption related to max-fd

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Version 0.9.1 (UNRELEASED)
     - Adds support for Kubernetes clusters 1.26.
     - Adds new configuration option ``ingress.extra`` to define extra Ingress resources, in order to support redirecting HTTP requests to HTTPS with traefik v2 version.
     - Adds new configuration option ``ingress.tls.hosts`` to define hosts that are present in the TLS certificate, in order to support cert-manager's automatic creation of certificates.
+    - Fixes uWSGI memory consumption on systems with very high allowed number of open files.
 
 Version 0.9.0 (2023-01-26)
 --------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Version 0.9.1 (UNRELEASED)
     - Adds support for Kubernetes clusters 1.26.
     - Adds new configuration option ``ingress.extra`` to define extra Ingress resources, in order to support redirecting HTTP requests to HTTPS with traefik v2 version.
     - Adds new configuration option ``ingress.tls.hosts`` to define hosts that are present in the TLS certificate, in order to support cert-manager's automatic creation of certificates.
+    - Changes uWSGI configuration to add vacuuming of generated files and sockets.
     - Fixes uWSGI memory consumption on systems with very high allowed number of open files.
 
 Version 0.9.0 (2023-01-26)

--- a/helm/reana/templates/uwsgi-config.yaml
+++ b/helm/reana/templates/uwsgi-config.yaml
@@ -13,8 +13,10 @@ data:
     master = true
     processes = {{ .Values.components.reana_server.uwsgi.processes }}
     threads = {{ .Values.components.reana_server.uwsgi.threads }}
+    enable-threads = true
     single-interpreter = true
     need-app = true
+    vacuum = true
     wsgi-disable-file-wrapper = true
 
     auto-procname = true

--- a/helm/reana/templates/uwsgi-config.yaml
+++ b/helm/reana/templates/uwsgi-config.yaml
@@ -44,3 +44,6 @@ data:
 
     # enable keepalive to avoid 500/502 from traefik
     http-keepalive = 1
+
+    # fix uWSGI memory consumption on systems with very high fs.nr_open limits
+    max-fd = 1048576


### PR DESCRIPTION
Fixes memory consumption of the "uWSGI http 1" process that was rising above 8 GiB on systems like Fedora 37 (locally) and Fedora CoreOS 36 (in the cloud) due to very high file descriptor limits (`fs.nr_open = 1073741816`). See <https://github.com/kubernetes-sigs/kind/issues/2175> and <https://github.com/unbit/uwsgi/issues/2299>.

Sets the uWSGI `max-fd` value to 1048576 as per
<https://github.com/kubernetes-sigs/kind/pull/1799/files>. If need be, we can make it configurable via Helm chart values later.