### PR TITLE
helm: Kubernetes 1.27

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Version 0.9.1 (UNRELEASED)
 - Administrators:
     - Adds new configuration option ``interactive_sessions.maximum_inactivity_period`` to set a limit in days for the maximum inactivity period of interactive sessions after which they will be closed.
     - Adds new configuration option ``interactive_sessions.cronjob_schedule`` to set how often interactive session cleanup should be performed.
-    - Adds support for Kubernetes clusters 1.26.
+    - Adds support for Kubernetes clusters 1.26, 1.27.
     - Adds new configuration option ``ingress.extra`` to define extra Ingress resources, in order to support redirecting HTTP requests to HTTPS with traefik v2 version.
     - Adds new configuration option ``ingress.tls.hosts`` to define hosts that are present in the TLS certificate, in order to support cert-manager's automatic creation of certificates.
     - Changes uWSGI configuration to add vacuuming of generated files and sockets.

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
 type: application
 # Chart version.
 version: 0.9.1-alpha.1
-kubeVersion: ">= 1.21.0-0 < 1.27.0-0"
+kubeVersion: ">= 1.21.0-0 < 1.28.0-0"
 dependencies:
   - name: traefik
     version: 10.6.2

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -43,7 +43,7 @@ install_requires = [
     "click>=7",
     "colorama>=0.3.9",
     "PyYAML>=5.1,<6.0",
-    "semver>=2.10.2",
+    "semver>=2.10.2,<3.0.0",
     "packaging>=20.4",
 ]
 


### PR DESCRIPTION
Declares support for Kubernetes 1.27 that was successfully tested locally using Kind 0.18 with the image
`kindest/node:v1.27.1@sha256:9915f5629ef4d29f35b478e819249e89cfaffcbfeebda4324e5c01d53d937b09`.