### PR TITLE
helm: add missing env variables to cronjobs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Version 0.9.1 (UNRELEASED)
     - Adds new configuration option ``notifications.email_config.smtp_starttls`` to use the STARTTLS command to enable encryption after connecting to the SMTP email server.
     - Changes uWSGI configuration to add vacuuming of generated files and sockets.
     - Fixes uWSGI memory consumption on systems with very high allowed number of open files.
+    - Fixes cronjob failures due to database connection issues when REANA is deployed with non-default namespace or prefix.
     - Adds new configuration options ``login`` and ``secrets.login`` for configuring Keycloak SSO login with third-party authentication services.
 
 Version 0.9.0 (2023-01-26)

--- a/helm/reana/templates/cronjobs.yaml
+++ b/helm/reana/templates/cronjobs.yaml
@@ -148,6 +148,10 @@ spec:
             env:
             - name: REANA_PERIODIC_RESOURCE_QUOTA_UPDATE_POLICY
               value: "true"
+            {{- if .Values.reana_hostname }}
+            - name: REANA_HOSTNAME
+              value: {{ .Values.reana_hostname }}
+            {{- end }}
             {{- range $key, $value := .Values.db_env_config }}
             - name: {{ $key }}
               value: {{ $value | quote }}
@@ -167,6 +171,12 @@ spec:
                   name: {{ include "reana.prefix" . }}-db-secrets
                   key: password
             {{- end }}
+            - name: REANA_COMPONENT_PREFIX
+              value: {{ include "reana.prefix" . }}
+            - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
+              value: {{ .Values.namespace_runtime | default .Release.Namespace }}
             volumeMounts:
               {{- if .Values.debug.enabled }}
               - mountPath: /code/
@@ -221,6 +231,10 @@ spec:
             stdin: true
             {{- end }}
             env:
+            {{- if .Values.reana_hostname }}
+            - name: REANA_HOSTNAME
+              value: {{ .Values.reana_hostname }}
+            {{- end }}
             {{- range $key, $value := .Values.db_env_config }}
             - name: {{ $key }}
               value: {{ $value | quote }}
@@ -240,6 +254,12 @@ spec:
                   name: {{ include "reana.prefix" . }}-db-secrets
                   key: password
             {{- end }}
+            - name: REANA_COMPONENT_PREFIX
+              value: {{ include "reana.prefix" . }}
+            - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
+              value: {{ .Values.namespace_runtime | default .Release.Namespace }}
             volumeMounts:
               {{- if .Values.debug.enabled }}
               - mountPath: /code/
@@ -318,6 +338,12 @@ spec:
                   name: {{ include "reana.prefix" . }}-db-secrets
                   key: password
             {{- end }}
+            - name: REANA_COMPONENT_PREFIX
+              value: {{ include "reana.prefix" . }}
+            - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
+              value: {{ .Values.namespace_runtime | default .Release.Namespace }}
             volumeMounts:
               {{- if .Values.debug.enabled }}
               - mountPath: /code/


### PR DESCRIPTION
Add missing environment variables that caused cronjobs to fail to
connect to the database when REANA is deployed with a non-default
namespace or prefix.

Closes #711
