### PR TITLE
helm: fix enabling/disabling Ingresses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Version 0.9.1 (UNRELEASED)
     - Changes uWSGI configuration to add vacuuming of generated files and sockets.
     - Fixes uWSGI memory consumption on systems with very high allowed number of open files.
     - Fixes cronjob failures due to database connection issues when REANA is deployed with non-default namespace or prefix.
+    - Fixes ``ingress.enabled`` option to correctly enable or disable the creation of Ingresses.
     - Adds new configuration options ``login`` and ``secrets.login`` for configuring Keycloak SSO login with third-party authentication services.
 
 Version 0.9.0 (2023-01-26)

--- a/helm/reana/templates/ingress.yaml
+++ b/helm/reana/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 {{- range (concat (list .Values.ingress) .Values.ingress.extra) }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -63,4 +64,5 @@ spec:
       {{- if $.Values.reana_hostname }}
       host: {{ $.Values.reana_hostname }}
       {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Fix ``ingress.enabled`` option to correctly enable or disable the
creation of Ingresses.
