### PR TITLE
helm: add env variable for session inactivity to server

### DIFF
--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -86,6 +86,8 @@ spec:
           {{- end }}
           - name: REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT
             value: !!str {{ .Values.kubernetes_jobs_max_user_timeout_limit | default 1209600 }}  # 1209600 seconds = 14 days
+          - name: REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD
+            value: {{ .Values.interactive_sessions.maximum_inactivity_period | default "forever" | quote }}
           - name: REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT
             value: !!str {{ .Values.kubernetes_jobs_timeout_limit | default 604800 }}  # 604800 seconds = 7 days
           - name: REANA_KUBERNETES_JOBS_MEMORY_LIMIT


### PR DESCRIPTION
Adds an env variable that contains the maximum number of days for which an interactive session can stay inactive before being automaticallly closed.

Closes reanahub/reana-client#657