### PR TITLE
cronjobs: add secret key and admin access token to environment

### DIFF
--- a/helm/reana/templates/cronjobs.yaml
+++ b/helm/reana/templates/cronjobs.yaml
@@ -86,6 +86,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "reana.prefix" . }}-admin-access-token
                   key: ADMIN_ACCESS_TOKEN
+            - name: REANA_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reana.prefix" . }}-secrets
+                  key: REANA_SECRET_KEY
             - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
               value: {{ .Release.Namespace }}
             - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
@@ -256,6 +261,16 @@ spec:
             {{- end }}
             - name: REANA_COMPONENT_PREFIX
               value: {{ include "reana.prefix" . }}
+            - name: REANA_ADMIN_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reana.prefix" . }}-admin-access-token
+                  key: ADMIN_ACCESS_TOKEN
+            - name: REANA_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reana.prefix" . }}-secrets
+                  key: REANA_SECRET_KEY
             - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
               value: {{ .Release.Namespace }}
             - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
@@ -340,6 +355,16 @@ spec:
             {{- end }}
             - name: REANA_COMPONENT_PREFIX
               value: {{ include "reana.prefix" . }}
+            - name: REANA_ADMIN_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reana.prefix" . }}-admin-access-token
+                  key: ADMIN_ACCESS_TOKEN
+            - name: REANA_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reana.prefix" . }}-secrets
+                  key: REANA_SECRET_KEY
             - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
               value: {{ .Release.Namespace }}
             - name: REANA_RUNTIME_KUBERNETES_NAMESPACE


### PR DESCRIPTION
Add `REANA_SECRET_KEY` and `REANA_ADMIN_ACCESS_TOKEN` environment
variables to cronjobs. The former is needed to decrypt the tokens in the
database, the latter is needed to execute `reana-admin` commands.

Closes reanahub/reana-server#489
