### PR TITLE
helm: fix SSL/STARTTLS configuration

### DIFF
--- a/helm/reana/templates/cronjobs.yaml
+++ b/helm/reana/templates/cronjobs.yaml
@@ -61,13 +61,13 @@ spec:
             - name: REANA_EMAIL_SMTP_PORT
               value: "{{ .Values.notifications.email_config.smtp_port | default "30025" }}"
             - name: REANA_EMAIL_SMTP_SSL
-              value: {{ .Values.notifications.email_config.smtp_ssl | default "false" | quote }}
+              value: {{ .Values.notifications.email_config.smtp_ssl | quote }}
             {{- if .Values.debug.enabled }}
             - name: REANA_EMAIL_SMTP_STARTTLS
               value: "false"
             {{- else }}
             - name: REANA_EMAIL_SMTP_STARTTLS
-              value: {{ .Values.notifications.email_config.smtp_starttls | default "true" | quote }}
+              value: {{ .Values.notifications.email_config.smtp_starttls | quote }}
             - name: REANA_EMAIL_LOGIN
               valueFrom:
                 secretKeyRef:

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -187,13 +187,13 @@ spec:
           - name: REANA_EMAIL_SMTP_PORT
             value: "{{ .Values.notifications.email_config.smtp_port | default "30025" }}"
           - name: REANA_EMAIL_SMTP_SSL
-            value: {{ .Values.notifications.email_config.smtp_ssl | default "false" | quote }}
+            value: {{ .Values.notifications.email_config.smtp_ssl | quote }}
           {{- if .Values.debug.enabled }}
           - name: REANA_EMAIL_SMTP_STARTTLS
             value: "false"
           {{- else }}
           - name: REANA_EMAIL_SMTP_STARTTLS
-            value: {{ .Values.notifications.email_config.smtp_starttls | default "true" | quote }}
+            value: {{ .Values.notifications.email_config.smtp_starttls | quote }}
           - name: REANA_EMAIL_LOGIN
             valueFrom:
               secretKeyRef:

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -120,7 +120,9 @@ components:
 
 notifications:
   enabled: false
-  email_config: {}
+  email_config:
+    smtp_starttls: true
+    smtp_ssl: false
   system_status: "0 0 * * *"
 
 # Accessing the cluster from outside world


### PR DESCRIPTION
Avoid using `default` when setting boolean values, as `false` is
interpreted as an empty value.

Closes #725


How to test:
1. Set `smtp_starttls` and `smtp_ssl` to different values, like:

    ```yaml
    notifications:
      enabled: true
      email_config:
        smtp_starttls: false
    ```
2. Check that the values are correctly set inside the pods:
    ```
    kubectl exec deployment/reana-server -- env | grep -i smtp
    ```