### PR TITLE
helm: Kubernetes 1.28

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Version 0.9.1 (UNRELEASED)
 - Administrators:
     - Adds new configuration option ``interactive_sessions.maximum_inactivity_period`` to set a limit in days for the maximum inactivity period of interactive sessions after which they will be closed.
     - Adds new configuration option ``interactive_sessions.cronjob_schedule`` to set how often interactive session cleanup should be performed.
-    - Adds support for Kubernetes clusters 1.26, 1.27.
+    - Adds support for Kubernetes clusters 1.26, 1.27, 1.28.
     - Adds new configuration option ``ingress.extra`` to define extra Ingress resources, in order to support redirecting HTTP requests to HTTPS with traefik v2 version.
     - Adds new configuration option ``ingress.tls.hosts`` to define hosts that are present in the TLS certificate, in order to support cert-manager's automatic creation of certificates.
     - Adds new configuration option ``notifications.email_config.smtp_ssl`` to use SSL when connecting to the SMTP email server.

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
 type: application
 # Chart version.
 version: 0.9.1-alpha.4
-kubeVersion: ">= 1.21.0-0 < 1.28.0-0"
+kubeVersion: ">= 1.21.0-0 < 1.29.0-0"
 dependencies:
   - name: traefik
     version: 10.6.2


### PR DESCRIPTION
Declares support for Kubernetes 1.28 that was successfully tested locally using Kind 0.20 with the image
`kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31`.