### PR TITLE
helm: fix graceful shutdown for reana-server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Version 0.9.1 (UNRELEASED)
     - Fixes uWSGI memory consumption on systems with very high allowed number of open files.
     - Fixes cronjob failures due to database connection issues when REANA is deployed with non-default namespace or prefix.
     - Fixes ``ingress.enabled`` option to correctly enable or disable the creation of Ingresses.
+    - Fixes graceful shutdown for reana-server and reana-workflow-controller.
     - Adds new configuration options ``login`` and ``secrets.login`` for configuring Keycloak SSO login with third-party authentication services.
 - Developers:
     - Fixes ``cluster-deploy``, ``cluster-undeploy`` and ``client-setup-environment`` commands when using custom instance name or kubernetes namespace.

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -43,8 +43,8 @@ spec:
         tty: true
         stdin: true
         {{- else }}
-        command: ["/bin/sh", "-c"]
-        args: ["uwsgi --ini /var/reana/uwsgi/uwsgi.ini"]
+        # do not use "/bin/sh -c" here as that breaks signal propagation
+        command: ["uwsgi", "--ini", "/var/reana/uwsgi/uwsgi.ini"]
         {{- end }}
         volumeMounts:
           {{- if .Values.debug.enabled }}


### PR DESCRIPTION
Avoid using `/bin/sh -c` to run uwsgi, as that breaks signal
propagation.

Closes reanahub/reana-job-controller#347

**How to test:**
- Check out the following PRs:
  - https://github.com/reanahub/reana/pull/747
  - https://github.com/reanahub/reana-server/pull/629
  - https://github.com/reanahub/reana-workflow-controller/pull/526
- Deploy the cluster in non-debug mode
- Delete reana-server/reana-workflow-controller pods

**Expected behaviour:**
The pods are terminated "fast", that is without waiting the standard k8s grace period of 30s, and the logs show:

rest-api:
```
[...]
Gracefully killing worker 1 (pid: 16)...
Gracefully killing worker 2 (pid: 18)...
worker 1 buried after 1 seconds
worker 2 buried after 1 seconds
goodbye to uWSGI.
VACUUM: unix socket /tmp/stats.socket (stats) removed.
```

scheduler/job-status-consumer:
```
... | root | MainThread | INFO | Starting job status consumer...
[...]
... | root | MainThread | INFO | Stopping job status consumer...
```
