### PR TITLE
dev: improve python-run-tests execution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Version 0.9.2 (UNRELEASED)
+--------------------------
+
+- Developers:
+    - Changes `python-run-tests` command to allow execution of selected pytests only by passing over `PYTEST_ADDOPTS` environment variable.
+    - Changes `python-run-tests` command to allow excluding certain Python components.
+    - Fixes `python-run-tests` command to create Python-3.8 based virtual environments to use the same version as container images.
+
 Version 0.9.1 (2023-09-27)
 --------------------------
 

--- a/reana/config.py
+++ b/reana/config.py
@@ -293,5 +293,8 @@ GITHUB_REANAHUB_URL = "https://github.com/reanahub"
 CODECOV_REANAHUB_URL = "https://codecov.io/gh/reanahub"
 """REANA Hub organisation Codecov URL."""
 
+PYTHON_EXECUTABLE_NAME = "python3.8"
+"""Python executable name with the same version as cluster components."""
+
 PYTHON_DOCKER_IMAGE = "docker.io/library/python:3.8"
-"""Python docker image with same version as cluster components."""
+"""Python docker image with the same version as cluster components."""


### PR DESCRIPTION
Improves the `python-run-tests` command to create Python-3.8 based virtual environments to use the same version as container images.

Updates `pip` before installing each component in order to speed up the dependency resolution for certain cluster components.

Allows execution of selected pytests only by passing over `PYTEST_ADDOPTS` environment variable.

Switches to using `run-tests.sh` to execute pytests in individual components which takes care of the DB setup at the source.

Allows excluding certain Python components such as `-c CLUSTER --exclude-components r-j-controller` on macOS.

Example:

```
$ PYTEST_ADDOPTS=tests/test_version.py reana-dev python-unit-tests -c ALL -k
```

Closes #755.