### PR TITLE
dev: delete extra file when running git-submodule --update

### DIFF
--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -633,12 +633,12 @@ def git_submodule(update=False, status=False, delete=False):  # noqa: D301
     if update:
         for component in COMPONENTS_USING_SHARED_MODULE_COMMONS:
             for cmd in [
-                "rsync -az ../reana-commons modules",
+                "rsync -az --delete ../reana-commons modules",
             ]:
                 run_command(cmd, component)
         for component in COMPONENTS_USING_SHARED_MODULE_DB:
             for cmd in [
-                "rsync -az ../reana-db modules",
+                "rsync -az --delete ../reana-db modules",
             ]:
                 run_command(cmd, component)
     elif delete:


### PR DESCRIPTION
Change the `git-submodule --update` command to delete from the `modules`
folder of the cluster components the files that are not present in the
original directories, reflecting a more accurate status of the shared
modules.

Closes #761.
