### PR TITLE
build(helm): add support for Kubernetes 1.29

### DIFF
--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
 type: application
 # Chart version.
 version: 0.9.2
-kubeVersion: ">= 1.21.0-0 < 1.29.0-0"
+kubeVersion: ">= 1.21.0-0 < 1.30.0-0"
 dependencies:
   - name: traefik
     version: 10.6.2


### PR DESCRIPTION
Declare support for Kubernetes 1.29 that was successfully tested locally using Kind 0.21.