### PR TITLE
Add compute4punch compute_backend

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -35,6 +35,7 @@ organisation on GitHub, in alphabetical order:
 - [Kenyi Hurtado-Anampa](https://orcid.org/0000-0002-9779-3566)
 - [Leticia Wanderley](https://orcid.org/0000-0003-4649-6630)
 - [Lukas Heinrich](https://orcid.org/0000-0002-4048-7584)
+- [Manuel Giffels](https://orcid.org/0000-0003-0193-3032)
 - [Marco Donadoni](https://orcid.org/0000-0003-2922-5505)
 - [Marco Vidal](https://orcid.org/0000-0002-9363-4971)
 - [Maria Fernando](https://github.com/MMFernando)

--- a/reana/config.py
+++ b/reana/config.py
@@ -131,7 +131,7 @@ REPO_LIST_PYTHON_REQUIREMENTS = [
 WORKFLOW_ENGINE_LIST_ALL = ["cwl", "serial", "yadage", "snakemake"]
 """List of supported workflow engines."""
 
-COMPUTE_BACKEND_LIST_ALL = ["kubernetes", "htcondorcern", "slurmcern"]
+COMPUTE_BACKEND_LIST_ALL = ["kubernetes", "htcondorcern", "slurmcern", "compute4punch"]
 """List of supported compute backends."""
 
 CLUSTER_DEPLOYMENT_MODES = ["releasehelm", "releasepypi", "latest", "debug"]

--- a/reana/reana_dev/cluster.py
+++ b/reana/reana_dev/cluster.py
@@ -183,7 +183,7 @@ def cluster_create(mounts, mode, worker_nodes, disable_default_cni):  # noqa: D3
     "--build-arg",
     "-b",
     multiple=True,
-    help="Any build arguments? (e.g. `-b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern`)",
+    help="Any build arguments? (e.g. `-b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern,compute4punch`)",
 )
 @click.option(
     "--mode",
@@ -214,7 +214,7 @@ def cluster_build(
     \b
     Example:
        $ reana-dev cluster-build --exclude-components=r-ui,r-a-vomsproxy
-                                 -b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern
+                                 -b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern,compute4punch
                                  --mode debug
                                  --no-cache
     """


### PR DESCRIPTION
This pull request adds the new `compute4punch` compute backend to the list of available compute backends. The `compute4punch` compute backend is currently implemented in https://github.com/reanahub/reana-job-controller/pull/430.