### PR TITLE
docs(chat): remove Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ depth information visit the [official REANA documentation](https://docs.reana.io
 ## Community
 
 - Discuss [on Forum](https://forum.reana.io/)
-- Chat on [Mattermost](https://mattermost.web.cern.ch/it-dep/channels/reana) or
-  [Gitter](https://gitter.im/reanahub/reana)
 - Follow us [on Twitter](https://twitter.com/reanahub)
+- Collaborate [on GitHub](https://github.com/reanahub)
 
 ## Useful links
 


### PR DESCRIPTION
Remove the mention of Gitter for chat that we don't use since a few years. Keep recommending Forum and Mattermost as the two main communication channels.