### PR TITLE
build(helm): add support for Kubernetes 1.30 (#799)

### DIFF
--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - reusable-science
 type: application
 version: 0.9.3
-kubeVersion: '>= 1.21.0-0 < 1.30.0-0'
+kubeVersion: '>= 1.21.0-0 < 1.31.0-0'
 dependencies:
   - name: traefik
     version: 10.6.2


### PR DESCRIPTION
Declare support for Kubernetes 1.30 that was successfully tested locally using Kind 0.23.