### PR TITLE
fix(helm): add NodePort services for debugging (#812)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -30,6 +30,7 @@ organisation on GitHub, in alphabetical order:
 - [Giuseppe Steduto](https://orcid.org/0009-0002-1258-8553)
 - [Harri Hirvonsalo](https://orcid.org/0000-0002-5503-510X)
 - [Jan Okraska](https://orcid.org/0000-0002-1416-3244)
+- [Jelizaveta Lemeševa](https://orcid.org/0009-0003-6606-9270)
 - [Jose Benito Gonzalez Lopez](https://orcid.org/0000-0002-0816-7126)
 - [Kati Lassila-Perini](https://orcid.org/0000-0002-5502-1795)
 - [Kenyi Hurtado-Anampa](https://orcid.org/0000-0002-9779-3566)

--- a/helm/reana/templates/reana-db.yaml
+++ b/helm/reana/templates/reana-db.yaml
@@ -13,6 +13,23 @@ spec:
   - port: 5432
     targetPort: 5432
     protocol: TCP
+{{- if .Values.debug.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "reana.prefix" . }}-db-debug
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: "NodePort"
+  selector:
+    app: {{ include "reana.prefix" . }}-db
+  ports:
+  - port: 5432
+    targetPort: 5432
+    nodePort: 30432
+    protocol: TCP
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/reana/templates/reana-message-broker.yaml
+++ b/helm/reana/templates/reana-message-broker.yaml
@@ -11,19 +11,30 @@ spec:
      targetPort: 5672
      name: "tcp"
      protocol: TCP
-  {{- if .Values.debug.enabled }}
-   - port: 31672
-     targetPort: 15672
-     name: "management"
-     protocol: TCP
-  {{- else }}
    - port: 15672
      targetPort: 15672
      name: "management"
      protocol: TCP
-  {{- end }}
   selector:
     app: {{ include "reana.prefix" . }}-message-broker
+{{- if .Values.debug.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "reana.prefix" . }}-message-broker-debug
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: "NodePort"
+  selector:
+    app: {{ include "reana.prefix" . }}-message-broker
+  ports:
+  - port: 15672
+    targetPort: 15672
+    nodePort: 31672
+    name: "management"
+    protocol: TCP
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/reana/reana_dev/cluster.py
+++ b/reana/reana_dev/cluster.py
@@ -124,6 +124,11 @@ def cluster_create(mounts, mode, worker_nodes, disable_default_cni):  # noqa: D3
                     "hostPort": 31672,
                     "protocol": "TCP",
                 },  # rabbitmq
+                {
+                    "containerPort": 30432,
+                    "hostPort": 30432,
+                    "protocol": "TCP",
+                },  # postgresql
             ]
         )
 


### PR DESCRIPTION
Current port mapping from Kubernetes service to localhosts for RabbitMQ debugging does not work (RabbitMQ has a nice UI that allows inspecting queues and messages). The reason is that `reana-message-broker` uses `ClusterIP` service instead of `NodePort`, which does not allow access from outside of the cluster (`reana-mail` uses NodePort and works fine). I can think of two ways of fixing it - either delete broken code from `cluster.py` and use `kubectl port-forward`, or add additional debug `NodePort` service to Helm chart (we already have `debug.enabled` flag). This PR implements the latter, as it simplifies running REANA cluster in debugging mode.

Also adding debug service for PostgreSQL which would allow connecting to it via PostgreSQL client on host machine.

Kubernetes services before:
```
$ kubectl get svc                      
NAME                        TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
kubernetes                  ClusterIP   10.96.0.1       <none>        443/TCP                           4m39s
reana-cache                 ClusterIP   10.96.5.244     <none>        6379/TCP                          12s
reana-db                    ClusterIP   10.96.7.93      <none>        5432/TCP                          12s
reana-mail                  NodePort    10.96.96.82     <none>        30025:30025/TCP,32580:32580/TCP   12s
reana-message-broker        ClusterIP   10.96.99.186    <none>        5672/TCP,31672/TCP                12s <-- no mapping
reana-server                ClusterIP   10.96.89.209    <none>        80/TCP                            12s
reana-traefik               NodePort    10.96.249.50    <none>        80:30080/TCP,443:30443/TCP        12s
reana-ui                    ClusterIP   10.96.242.48    <none>        80/TCP                            12s
reana-wdb                   NodePort    10.96.148.252   <none>        19840:32376/TCP,1984:31984/TCP    12s
reana-workflow-controller   ClusterIP   10.96.45.226    <none>        80/TCP
```
Kubernetes services after:
```
$ kubectl get svc 
NAME                         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                           AGE
kubernetes                   ClusterIP   10.96.0.1       <none>        443/TCP                           3m35s
reana-cache                  ClusterIP   10.96.99.130    <none>        6379/TCP                          17s
reana-db                     ClusterIP   10.96.166.11    <none>        5432/TCP                          17s
reana-db-debug               NodePort    10.96.199.69    <none>        5432:30432/TCP                    17s <-- mapping
reana-mail                   NodePort    10.96.123.33    <none>        30025:30025/TCP,32580:32580/TCP   17s
reana-message-broker         ClusterIP   10.96.82.13     <none>        5672/TCP,15672/TCP                17s
reana-message-broker-debug   NodePort    10.96.154.13    <none>        15672:31672/TCP                   17s <-- mapping
reana-server                 ClusterIP   10.96.78.78     <none>        80/TCP                            17s
reana-traefik                NodePort    10.96.222.115   <none>        80:30080/TCP,443:30443/TCP        17s
reana-ui                     ClusterIP   10.96.92.124    <none>        80/TCP                            17s
reana-wdb                    NodePort    10.96.146.200   <none>        19840:31633/TCP,1984:31984/TCP    17s
reana-workflow-controller    ClusterIP   10.96.169.253   <none>        80/TCP                            17s
```