### PR TITLE
deprecations setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -65,7 +65,7 @@ check_sphinx () {
 }
 
 check_pytest () {
-    python setup.py test
+    pytest
 }
 
 check_helm () {

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-[aliases]
-test = pytest
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,6 @@ install_requires = [
     "packaging>=20.4",
 ]
 
-
-setup_requires = [
-    "pytest-runner>=2.7",
-]
-
 packages = find_packages()
 
 
@@ -82,7 +77,6 @@ setup(
     python_requires=">=3.8",
     extras_require=extras_require,
     install_requires=install_requires,
-    setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,14 @@ from setuptools import find_packages, setup
 readme = open("README.md").read()
 history = open("CHANGELOG.md").read()
 
-tests_require = [
-    "pytest-reana>=0.9.2,<0.10.0",
-]
-
 extras_require = {
     "docs": [
         "myst-parser",
         "Sphinx>=1.5.1",
     ],
-    "tests": tests_require,
+    "tests": [
+        "pytest-reana>=0.9.2,<0.10.0",
+    ],
     "benchmark": [
         "pandas>=1.1.5",
         "matplotlib>=3.3.4",
@@ -77,7 +75,6 @@ setup(
     python_requires=">=3.8",
     extras_require=extras_require,
     install_requires=install_requires,
-    tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",


### PR DESCRIPTION
- **ci(pytest): invoke `pytest` directly instead of `setup.py test` (#815)**
- **build(python): remove deprecated `pytest-runner` (#815)**
- **build(python): use optional deps instead of `tests_require` (#815)**
- **build(python): add minimal `pyproject.toml` (#815)**

Closes https://github.com/reanahub/reana/issues/814
