### PR TITLE
feat(reana_dev): add no_update_submodules flag (#816)

### DIFF
--- a/reana/reana_dev/cluster.py
+++ b/reana/reana_dev/cluster.py
@@ -210,9 +210,20 @@ def cluster_create(mounts, mode, worker_nodes, disable_default_cni):  # noqa: D3
     type=click.IntRange(min=1),
     help="Number of docker images to build in parallel.",
 )
+@click.option(
+    "--no-update-submodules",
+    is_flag=True,
+    help="Do not update git submodules.",
+)
 @cluster_commands.command(name="cluster-build")
 def cluster_build(
-    build_arg, mode, exclude_components, no_cache, skip_load, parallel
+    build_arg,
+    mode,
+    exclude_components,
+    no_cache,
+    skip_load,
+    parallel,
+    no_update_submodules,
 ):  # noqa: D301
     """Build REANA cluster.
 
@@ -225,7 +236,7 @@ def cluster_build(
     """
     cmds = []
     # initalise common submodules
-    if mode in ("latest", "debug"):
+    if mode in ("latest", "debug") and not no_update_submodules:
         cmds.append("reana-dev git-submodule --update")
     # build Docker images
     cmd = "reana-dev docker-build"
@@ -294,6 +305,11 @@ def cluster_build(
     default="reana",
     help="REANA instance name",
 )
+@click.option(
+    "--no-update-submodules",
+    is_flag=True,
+    help="Do not update git submodules.",
+)
 def cluster_deploy(
     namespace,
     job_mounts,
@@ -303,6 +319,7 @@ def cluster_deploy(
     admin_email,
     admin_password,
     instance_name,
+    no_update_submodules,
 ):  # noqa: D301
     """Deploy REANA cluster.
 
@@ -362,7 +379,8 @@ def cluster_deploy(
     cmds = []
     if mode in ("debug"):
         cmds.append("reana-dev python-install-eggs")
-        cmds.append("reana-dev git-submodule --update")
+        if not no_update_submodules:
+            cmds.append("reana-dev git-submodule --update")
     cmds.extend(
         [
             "helm dep update helm/reana",


### PR DESCRIPTION
Add `--no-update-submodules` flag to `reana-dev` commands `cluster-build` and `cluster-deploy`.

`reana-commons` `adage` lib version have been upgraded (needed for Ubuntu upgrade to 24.04, Python to 3.12), but other components still require older version. As `reana-commons` is a submodule, docker image builds fail for certain components (`reana-server` and `reana-workflow-engine-yadage`):

```
[2024-08-05T10:34:56] reana-server: docker build -t docker.io/reanahub/reana-server:latest .
[+] Building 7.6s (14/14) FINISHED                                                                                                               docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                             0.0s
 => => transferring dockerfile: 3.52kB                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                  0.8s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                                0.0s
 => => transferring context: 370B                                                                                                                                0.0s
 => [1/9] FROM docker.io/library/ubuntu:20.04@sha256:0b897358ff6624825fb50d20ffb605ab0eaea77ced0adb8c6a4b756513dec6fc                                            0.0s
 => [internal] load build context                                                                                                                                0.1s
 => => transferring context: 216.40kB                                                                                                                            0.1s
 => CACHED [2/9] COPY requirements.txt /code/                                                                                                                    0.0s
 => CACHED [3/9] RUN apt-get update -y &&     apt-get install --no-install-recommends -y       gcc       git       libffi-dev       libpcre3       libpcre3-dev  0.0s
 => CACHED [4/9] WORKDIR /code                                                                                                                                   0.0s
 => CACHED [5/9] COPY . /code                                                                                                                                    0.0s
 => [6/9] RUN if [ "0" -gt 0 ]; then pip install --no-cache-dir -e ".[debug]"; else pip install --no-cache-dir .; fi;                                            2.3s
 => [7/9] RUN if test -e modules/reana-commons; then       if [ "0" -gt 0 ]; then         pip install --no-cache-dir -e "modules/reana-commons[kubernetes,yadag  3.9s
 => [8/9] RUN sed -i 's|^username_regex = re.compile\(.*\)$|username_regex = re.compile("^\\S+$")|g' /usr/local/lib/python3.8/dist-packages/invenio_userprofile  0.1s 
 => ERROR [9/9] RUN pip check                                                                                                                                    0.4s 
------                                                                                                                                                                
 > [9/9] RUN pip check:                                                                                                                                               
0.362 reana-server 0.95.0a1 has requirement adage==0.10.1, but you have adage 0.11.0.                                                                                 
------                                                                                                                                                                
Dockerfile:75
--------------------
  73 |     # Check for any broken Python dependencies
  74 |     # hadolint ignore=DL3059
  75 | >>> RUN pip check
  76 |     
  77 |     # Set useful environment variables
--------------------
ERROR: failed to solve: process "/bin/sh -c pip check" did not complete successfully: exit code: 1
[2024-08-05T10:34:56] reana-server: Command 'docker build -t docker.io/reanahub/reana-server:latest .' returned non-zero exit status 1.
```

Add a flag to skip submodule update if `debug` mode is used. Adding this flag (instead of e. g. `--update-submodule` and not doing submodule update by default in `debug` mode) to not interfere with current development flow.