### PR TITLE
feat(reana-dev): change run-example to use gherkin-parser module (#817)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@ organisation on GitHub, in alphabetical order:
 
 - [Adelina Lintuluoto](https://orcid.org/0000-0002-0726-1452)
 - [Agisilaos Kounelis](https://orcid.org/0000-0001-9312-3189)
+- [Alastair Lyall](https://orcid.org/0009-0000-4955-8935)
 - [Alizee Pace](https://www.linkedin.com/in/aliz%C3%A9e-pace-516b4314b/)
 - [Alp Tuna](https://orcid.org/0009-0001-1915-3993)
 - [Ana Trisovic](https://orcid.org/0000-0003-1991-0533)


### PR DESCRIPTION
Run-example now uses the test files in the specification file to check the correctness of the results (by running the test command).