### PR TITLE
chore(master): merge maint-0.9

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -36,6 +36,7 @@ organisation on GitHub, in alphabetical order:
 - [Kenyi Hurtado-Anampa](https://orcid.org/0000-0002-9779-3566)
 - [Leticia Wanderley](https://orcid.org/0000-0003-4649-6630)
 - [Lukas Heinrich](https://orcid.org/0000-0002-4048-7584)
+- [Manuel Giffels](https://orcid.org/0000-0003-0193-3032)
 - [Marco Donadoni](https://orcid.org/0000-0003-2922-5505)
 - [Marco Vidal](https://orcid.org/0000-0002-9363-4971)
 - [Maria Fernando](https://github.com/MMFernando)

--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - reusable-science
 type: application
 version: 0.9.3
-kubeVersion: '>= 1.21.0-0 < 1.31.0-0'
+kubeVersion: '>= 1.21.0-0 < 1.32.0-0'
 dependencies:
   - name: traefik
     version: 10.6.2

--- a/reana/config.py
+++ b/reana/config.py
@@ -128,7 +128,7 @@ REPO_LIST_PYTHON_REQUIREMENTS = [
 WORKFLOW_ENGINE_LIST_ALL = ["cwl", "serial", "yadage", "snakemake"]
 """List of supported workflow engines."""
 
-COMPUTE_BACKEND_LIST_ALL = ["kubernetes", "htcondorcern", "slurmcern"]
+COMPUTE_BACKEND_LIST_ALL = ["kubernetes", "htcondorcern", "slurmcern", "compute4punch"]
 """List of supported compute backends."""
 
 CLUSTER_DEPLOYMENT_MODES = ["releasehelm", "releasepypi", "latest", "debug"]

--- a/reana/reana_dev/cluster.py
+++ b/reana/reana_dev/cluster.py
@@ -188,7 +188,7 @@ def cluster_create(mounts, mode, worker_nodes, disable_default_cni):  # noqa: D3
     "--build-arg",
     "-b",
     multiple=True,
-    help="Any build arguments? (e.g. `-b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern`)",
+    help="Any build arguments? (e.g. `-b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern,compute4punch`)",
 )
 @click.option(
     "--mode",
@@ -219,7 +219,7 @@ def cluster_build(
     \b
     Example:
        $ reana-dev cluster-build --exclude-components=r-ui,r-a-vomsproxy
-                                 -b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern
+                                 -b COMPUTE_BACKENDS=kubernetes,htcondorcern,slurmcern,compute4punch
                                  --mode debug
                                  --no-cache
     """

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2020, 2021, 2022, 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.


### PR DESCRIPTION
build(helm): add support for Kubernetes 1.31 (#822)
ci(python): pin setuptools 70 (#822)
feat(config): add Compute4PUNCH backend (#780)

Note: The merge commit removes the changes related to pinning
`setuptools` to version 70, because this was only necessary for the
`maint-0.9` branches.
