### PR TITLE
feat(helm): upgrade traefik (#832)

### DIFF
--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -30,7 +30,7 @@ version: 0.9.3
 kubeVersion: '>= 1.21.0-0 < 1.32.0-0'
 dependencies:
   - name: traefik
-    version: 10.6.2
+    version: 31.1.0
     repository: https://helm.traefik.io/traefik
     condition: traefik.enabled
     tags:


### PR DESCRIPTION
I have realized that our `traefik` dependency is from 3 years ago. Updating the treaefik dependency resolved the linting error. I tested it with 5 different workflows and it seems to be working fine.

closes (#798)