### PR TITLE
fix(helm): improve opensearch deployment

### DIFF
--- a/helm/configurations/values-dev.yaml
+++ b/helm/configurations/values-dev.yaml
@@ -64,6 +64,8 @@ opensearch:
           key: OPENSEARCH_INITIAL_ADMIN_PASSWORD
   secretMounts: []
   customSecurityConfig:
+  podSecurityContext:
+    fsGroup: 0
 
 # FluentBit configuration for dev environment
 fluent-bit:

--- a/helm/reana/README.md
+++ b/helm/reana/README.md
@@ -141,7 +141,7 @@ This Helm automatically prefixes all names using the release name to avoid colli
 | `opensearch.tls.generate`                                | Enable the generation of a self-signed TLS certificates for OpenSearch               | true                                            |
 | `opensearch.tls.ca.cn`                                   | OpenSearch root CA certificate common name (CN)                                      | reana.io                                        |
 | `opensearch.tls.ca.ttl`                                  | OpenSearch root CA certificate TTL in days                                           | 365                                             |
-| `opensearch.tls.cert.cn`                                 | OpenSearch node certificate common name (CN)                                         | reana-opensearch-master.default.svc.cluster.local |
+| `opensearch.tls.cert.cn`                                 | OpenSearch node certificate common name (CN)                                         | reana-opensearch-master                         |
 | `opensearch.tls.cert.ttl`                                | OpenSearch node certificate TTL in days                                              | 180                                             |
 | `opensearch.tls.admin.cn`                                | OpenSearch admin certificate common name (CN)                                        | opensearch-admin.reana.io                       |
 | `opensearch.tls.admin.ttl`                               | OpenSearch admin certificate TTL in days                                             | 180                                             |

--- a/helm/reana/README.md
+++ b/helm/reana/README.md
@@ -58,7 +58,6 @@ This Helm automatically prefixes all names using the release name to avoid colli
 | `components.reana_workflow_controller.environment.REANA_OPENSEARCH_USE_SSL` | Use SSL when connecting to OpenSearch instance.                   | true                                            |
 | `components.reana_workflow_controller.environment.REANA_OPENSEARCH_CA_CERTS` | Path to a file with OpenSearch root CA certificates.             | "/code/certs/ca.crt"                            |
 | `components.reana_workflow_controller.environment.REANA_OPENSEARCH_USER` | OpenSearch user name for Basic Authentication.                       | reana                                           |
-| `components.reana_workflow_controller.environment.REANA_OPENSEARCH_PASSWORD` | OpenSearch password for Basic Authentication. Set this value in the Helm command. | ""                             |
 | `components.reana_workflow_engine_cwl.environment`       | [REANA-Workflow-Engine-CWL](https://github.com/reanahub/reana-workflow-engine-cwl) environment variables | `{}`                        |
 | `components.reana_workflow_engine_cwl.image`             | [REANA-Workflow-Engine-CWL image](https://hub.docker.com/r/reanahub/reana-workflow-engine-cwl) to use | `docker.io/reanahub/reana-workflow-engine-cwl:<chart-release-version>` |
 | `components.reana_workflow_engine_serial.environment`    | [REANA-Workflow-Engine-Serial](https://github.com/reanahub/reana-workflow-engine-serial) environment variables | `{}`                  |
@@ -162,6 +161,7 @@ This Helm automatically prefixes all names using the release name to avoid colli
 | `secrets.gitlab.REANA_GITLAB_OAUTH_APP_ID`               | GitLab OAuth application id                                                          | None                                            |
 | `secrets.gitlab.REANA_GITLAB_OAUTH_APP_SECRET`           | **[Do not use in production, use secrets instead]** GitLab OAuth application secret  | None                                            |
 | `secrets.login`                                          | **[Do not use in production, use secrets instead]** Third-party Keycloak identity provider consumer key and secret ([configuration details](https://docs.reana.io/administration/configuration/configuring-access/#keycloak-single-sign-on-configuration)) | `{}` |
+| `secrets.opensearch.password`                            | **[Do not use in production, use secrets instead]** OpenSearch password for Basic Authentication | None |
 | `secrets.reana.REANA_SECRET_KEY`                         | **[Do not use in production, use secrets instead]** REANA encryption secret key      | None                                            |
 | `serviceAccount.create`                                  | Create a service account for the REANA system user                                   | true                                            |
 | `serviceAccount.name`                                    | Service account name                                                                 | reana                                           |

--- a/helm/reana/templates/secrets.yaml
+++ b/helm/reana/templates/secrets.yaml
@@ -157,7 +157,7 @@ metadata:
     "helm.sh/resource-policy": keep
 type: Opaque
 data:
-  REANA_OPENSEARCH_PASSWORD: {{ .Values.components.reana_workflow_controller.environment.REANA_OPENSEARCH_PASSWORD | default "reana" | b64enc }}
+  REANA_OPENSEARCH_PASSWORD: {{ .Values.secrets.opensearch.password | default "reana" | b64enc }}
   {{- if not .Values.opensearch.securityConfig.enabled }}
   OPENSEARCH_INITIAL_ADMIN_PASSWORD: {{ .Values.opensearch.initialAdminPassword | default "reana" | b64enc }} # dev environment only
   {{- end }}

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -60,6 +60,7 @@ secrets:
     sso: {}
   reana: {}
   login: {}
+  opensearch: {}
 
 # Enable and configure SSO authentication via a third-party Keycloak identity provider
 login: []
@@ -116,7 +117,6 @@ components:
       REANA_OPENSEARCH_USE_SSL: true
       REANA_OPENSEARCH_CA_CERTS: "/code/certs/ca.crt"
       REANA_OPENSEARCH_USER: reana
-      REANA_OPENSEARCH_PASSWORD: ""  # Set this value in the Helm command
   reana_workflow_engine_cwl:
     image: docker.io/reanahub/reana-workflow-engine-cwl:0.9.3
     environment: {}

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -215,7 +215,7 @@ opensearch:
       cn: "reana.io"
       ttl: 365
     cert:
-      cn: "reana-opensearch-master.default.svc.cluster.local"
+      cn: "reana-opensearch-master"
       ttl: 180
     admin:
       cn: "opensearch-admin.reana.io"
@@ -382,7 +382,7 @@ fluent-bit:
     kubeCaFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     kubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   outputConfig:
-    host: reana-opensearch-master.default.svc.cluster.local
+    host: reana-opensearch-master
     httpUser: fluentbit
     httpPasswd:
     tls: "On"

--- a/reana/reana_dev/cluster.py
+++ b/reana/reana_dev/cluster.py
@@ -185,6 +185,10 @@ def cluster_create(
         cluster_config=yaml.dump(cluster_config),
     )
     run_command(cluster_create, "reana")
+    run_command(
+        "docker exec kind-control-plane sh -c 'mkdir -p /var/reana && chmod g+rwx /var/reana'",
+        "reana",
+    )
 
     # pull Docker images
     if mode in ("releasepypi", "latest", "debug"):


### PR DESCRIPTION
- **fix(helm): set `fsGroup` to zero for local opensearch deployment (#843)**
- **fix(helm): support OpenSearch deployment in non-default namespace (#843)**
- **fix(helm): avoid re-defining REANA_OPENSEARCH_PASSWORD (https://github.com/reanahub/reana/pull/843)**