### PR TITLE
feat(helm): release check on most-supported Kubernetes version

### DIFF
--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - reusable-science
 type: application
 version: 0.9.3
-kubeVersion: '>= 1.21.0-0 < 1.32.0-0'
+kubeVersion: '>= 1.21.0-0'
 dependencies:
   - name: traefik
     version: 10.6.2


### PR DESCRIPTION
Since Kubernetes 1.22, there was never a big need to actually upgrade REANA source code to make it work on new Kubernetes releases. (This is thanks to the fact that REANA uses pretty stable Kubernetes API internally.) This commit therefore releases the upper boundary check on the supported Kubernetes versions in order to be more welcoming to future Kubernetes upgrades, alleviating the need to manually bump the supported version number.