### PR TITLE
fix(reana-dev): correctly handle missing changelog of components (#858)

### DIFF
--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -1816,7 +1816,9 @@ def get_aggregate_changelog(previous_reana_client):  # noqa: D301
         )
 
         # also add current version, as it might not be tagged yet
-        versions_to_add.add(get_current_component_version_from_source_files(component))
+        current_version = get_current_component_version_from_source_files(component)
+        if current_version != prev_version:
+            versions_to_add.add(current_version)
 
         aggregated_changelog_lines += get_formatted_changelog_lines(
             component, versions_to_add


### PR DESCRIPTION
Fix `git-aggregate-changelog` to correctly handle components that were
not released for the new REANA release. Previously, the script was
aggregating the changelog of at least one version, even if it was
already part of a previous release.

Closes #857
