### PR TITLE
ci(helm): configure target branch name for helm linting

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -2,3 +2,4 @@ validate-maintainers: false
 check-version-increment: false
 chart-dirs:
   - helm
+target-branch: master


### PR DESCRIPTION
Our current helm linting github action looks for `main` branch. However, we are using `master` branch. We should explicitly specify `helm` in `target-branch` field.