### PR TITLE
feat(helm): update uWSGI config map

### DIFF
--- a/helm/reana/templates/uwsgi-config.yaml
+++ b/helm/reana/templates/uwsgi-config.yaml
@@ -34,9 +34,10 @@ data:
     {{- end }}
 
     # Workers management
+    idle = 60
     max-requests = 1999
     max-requests-delta = 149
-    # max-worker-lifetime = 3600 # https://github.com/unbit/uwsgi/issues/1894
+    max-worker-lifetime = 3600 # https://github.com/unbit/uwsgi/issues/1894
     reload-on-rss = 250
 
     # fix up signal handling


### PR DESCRIPTION
Add new uWSGI parameters after upgrading to version 2.0.28.

- `idle`: Restarts the worker after it has been idle for the specified number of seconds.
- `max-worker-lifetime`: Restarts the worker after running for the specified number of seconds.