### PR TITLE
fix(reana-dev): improve component detection from subdirectories

### DIFF
--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -648,12 +648,12 @@ def git_submodule(update=False, status=False, delete=False):  # noqa: D301
     if update:
         for component in COMPONENTS_USING_SHARED_MODULE_COMMONS:
             for cmd in [
-                "rsync -az --delete ../reana-commons modules",
+                "rsync -az --delete --exclude='.git' --exclude='.mise.toml' ../reana-commons modules",
             ]:
                 run_command(cmd, component)
         for component in COMPONENTS_USING_SHARED_MODULE_DB:
             for cmd in [
-                "rsync -az --delete ../reana-db modules",
+                "rsync -az --delete --exclude='.git' --exclude='.mise.toml' ../reana-db modules",
             ]:
                 run_command(cmd, component)
     elif delete:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,8 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Tests for reana_dev/utils.py"""
+import os
+import tempfile
 import pytest
 
 
@@ -52,3 +54,72 @@ class TestParsePep440Version:
         from reana.reana_dev.utils import parse_pep440_version
 
         assert str(parse_pep440_version(original)) == expected
+
+
+class TestFindComponentDirectoryFromCurrentDir:
+    def test_find_component_from_nested_directory(self):
+        """Test that component is detected from nested subdirectories."""
+        from reana.reana_dev.utils import find_component_directory_from_current_dir
+
+        # Save current directory
+        original_dir = os.getcwd()
+
+        try:
+            # Create a temporary directory structure: component/.git and component/tests/subdir
+            with tempfile.TemporaryDirectory() as tmpdir:
+                component_dir = os.path.join(tmpdir, "reana-server")
+                git_dir = os.path.join(component_dir, ".git")
+                tests_dir = os.path.join(component_dir, "tests")
+                subdir = os.path.join(tests_dir, "subdir")
+
+                os.makedirs(git_dir)
+                os.makedirs(subdir)
+
+                # Resolve symlinks for comparison (e.g., /var -> /private/var on macOS)
+                component_dir_real = os.path.realpath(component_dir)
+
+                # Test from component root
+                os.chdir(component_dir)
+                assert (
+                    os.path.realpath(find_component_directory_from_current_dir())
+                    == component_dir_real
+                )
+
+                # Test from nested tests directory
+                os.chdir(tests_dir)
+                assert (
+                    os.path.realpath(find_component_directory_from_current_dir())
+                    == component_dir_real
+                )
+
+                # Test from deeply nested subdirectory
+                os.chdir(subdir)
+                assert (
+                    os.path.realpath(find_component_directory_from_current_dir())
+                    == component_dir_real
+                )
+
+        finally:
+            # Restore original directory
+            os.chdir(original_dir)
+
+    def test_find_component_fails_without_git(self):
+        """Test that an exception is raised when no .git directory is found."""
+        from reana.reana_dev.utils import find_component_directory_from_current_dir
+
+        # Save current directory
+        original_dir = os.getcwd()
+
+        try:
+            # Create a temporary directory without .git
+            with tempfile.TemporaryDirectory() as tmpdir:
+                no_git_dir = os.path.join(tmpdir, "no-git-component")
+                os.makedirs(no_git_dir)
+                os.chdir(no_git_dir)
+
+                with pytest.raises(Exception, match="Cannot find .git directory"):
+                    find_component_directory_from_current_dir()
+
+        finally:
+            # Restore original directory
+            os.chdir(original_dir)


### PR DESCRIPTION
This commit enhances component detection to work correctly when running `reana-dev` commands from nested subdirectories within a component.

Also excludes `.git` and `.mise.toml` from `rsync` operations in `git-submodule` command to prevent nested git repositories and virtual environments in `<reana-component>/modules/` directories. The `reana-dev` family of commands will now properly detect that we are in the `<reana-component>` in these cases.