### PR TITLE
feat(reana-dev): use Docker Buildx for multi-arch image releases

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
This commit changes the Docker image building and releasing workflow to use Docker Buildx instead of Podman for multi-arch image builds.

The `release-docker` command now builds and pushes images using Docker Buildx, matching exactly what the GitHub Actions release workflow does. The `release-docker` command now supports the `--build-arg` and the `--no-cache` options and defaults to creating multi-arch builds (`linux/amd64`, `linux/arm64`).

BREAKING CHANGE: The `docker-build` command is now intended for single-platform local development builds only, and the `docker-push` command has been fully deprecated in favour of `release-docker`.