### PR TITLE
feat(reana-dev): add support for pyproject.toml components

### DIFF
--- a/reana/reana_dev/client.py
+++ b/reana/reana_dev/client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2022, 2023 CERN.
+# Copyright (C) 2020, 2022, 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -30,7 +30,7 @@ def client_install():  # noqa: D301
     """Install latest REANA client and its dependencies."""
     for component in REPO_LIST_CLIENT:
         for cmd in [
-            "if [ -e setup.py ]; then pip install . --upgrade; fi",
+            "if [ -e setup.py ] || [ -e pyproject.toml ]; then pip install . --upgrade; fi",
         ]:
             run_command(cmd, component)
     run_command("pip check", "reana")

--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2023, 2024, 2025 CERN.
+# Copyright (C) 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -1300,7 +1300,11 @@ def git_upgrade_shared_modules(
             if amend:
                 commit_cmd = "git commit --amend --no-edit"
 
-            files_to_commit = ["setup.py"]
+            files_to_commit = []
+            if os.path.exists(get_srcdir(c) + os.sep + "setup.py"):
+                files_to_commit.append("setup.py")
+            if os.path.exists(get_srcdir(c) + os.sep + "pyproject.toml"):
+                files_to_commit.append("pyproject.toml")
             if os.path.exists(get_srcdir(c) + os.sep + "requirements.txt"):
                 files_to_commit.append("requirements.txt")
             run_command(

--- a/reana/reana_dev/python.py
+++ b/reana/reana_dev/python.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2020, 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -53,6 +53,8 @@ def is_component_python_package(component):
     """
     if os.path.exists(get_srcdir(component) + os.sep + "setup.py"):
         return True
+    if os.path.exists(get_srcdir(component) + os.sep + "pyproject.toml"):
+        return True
     return False
 
 
@@ -66,10 +68,7 @@ def python_install_eggs():
     """Create eggs-info/ in all REANA infrastructure and runtime components."""
     for component in REPO_LIST_CLUSTER:
         if is_component_python_package(component):
-            for cmd in [
-                "python setup.py bdist_egg",
-            ]:
-                run_command(cmd, component)
+            run_command("pip install -e .", component)
 
 
 @python_commands.command(name="python-unit-tests")
@@ -193,7 +192,7 @@ def python_unit_tests(
         else:
             msg = (
                 "Ignoring this component that does not contain"
-                " a Python setup.py file."
+                " a Python setup.py or pyproject.toml file."
             )
             display_message(msg, component)
 

--- a/reana/reana_dev/release.py
+++ b/reana/reana_dev/release.py
@@ -227,7 +227,7 @@ def release_pypi(ctx, component, timeout):  # noqa: D301
         is_component_releasable(component, exit_code=True, display=True)
         ctx.invoke(git_clean, component=[component])
 
-        for cmd in ["rm -rf dist", "python setup.py sdist", "twine upload ./dist/*"]:
+        for cmd in ["rm -rf dist", "python -m build --sdist", "twine upload ./dist/*"]:
             run_command(cmd, component)
 
         retry_interval = 15

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -576,13 +576,22 @@ def update_module_in_cluster_components(
 
         new_version_obj = Version(new_version)
         next_minor_version = f"{new_version_obj.major}.{new_version_obj.minor + 1}.0"
-        replace_string(
-            file_="setup.py",
-            find='>=.*,<.*[^",]',
-            replace=f">={new_version},<{next_minor_version}",
-            line_selector_regex=f"{module}.*>=",
-            component=component,
-        )
+        if os.path.exists(get_srcdir(component) + os.sep + "setup.py"):
+            replace_string(
+                file_="setup.py",
+                find='>=.*,<.*[^",]',
+                replace=f">={new_version},<{next_minor_version}",
+                line_selector_regex=f"{module}.*>=",
+                component=component,
+            )
+        if os.path.exists(get_srcdir(component) + os.sep + "pyproject.toml"):
+            replace_string(
+                file_="pyproject.toml",
+                find='>=.*,<.*[^",]',
+                replace=f">={new_version},<{next_minor_version}",
+                line_selector_regex=f"{module}.*>=",
+                component=component,
+            )
         if os.path.exists(get_srcdir(component) + os.sep + "requirements.txt"):
             replace_string(
                 file_="requirements.txt",


### PR DESCRIPTION
Adds support for `pyproject.toml` alongside `setup.py` for Python component detection and dependency management in various `reana-dev` commands.