### PR TITLE
fix(reana-dev): use PEP440 version format for reana-client tags

### DIFF
--- a/reana/config.py
+++ b/reana/config.py
@@ -132,6 +132,14 @@ REPO_LIST_PYTHON_REQUIREMENTS = [
 ]
 """List of cluster components that have a Python requirements file."""
 
+REPO_LIST_PYTHON_FIRST = [
+    "reana-client",
+]
+"""List of components that are Python packages first, Docker images second.
+
+For these components, the Python version (PEP440 format) takes precedence
+over the Docker version (semver2 format) for versioning and tagging purposes."""
+
 WORKFLOW_ENGINE_LIST_ALL = ["cwl", "serial", "yadage", "snakemake"]
 """List of supported workflow engines."""
 

--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -32,6 +32,7 @@ from reana.config import (
     REPO_LIST_ALL,
     REPO_LIST_CLUSTER_INFRASTRUCTURE,
     REPO_LIST_CLUSTER_RUNTIME_BATCH,
+    REPO_LIST_PYTHON_FIRST,
     REPO_LIST_PYTHON_REQUIREMENTS,
     REPO_LIST_SHARED,
 )
@@ -141,7 +142,10 @@ def git_create_release_branch(component: str, next_version: Optional[str]):
     if not next_version:
         # bump current version depending on whether it is semver2 or pep440
         current_version = get_current_component_version_from_source_files(component)
-        if version_files.get(DOCKER_VERSION_FILE):
+        if (
+            version_files.get(DOCKER_VERSION_FILE)
+            and component not in REPO_LIST_PYTHON_FIRST
+        ):
             next_version = bump_semver2_version(current_version)
         elif version_files.get(HELM_VERSION_FILE):
             next_version = bump_semver2_version(current_version)
@@ -155,6 +159,7 @@ def git_create_release_branch(component: str, next_version: Optional[str]):
         # provided next_version is always in pep440 version
         if (
             DOCKER_VERSION_FILE in version_files
+            and component not in REPO_LIST_PYTHON_FIRST
             or HELM_VERSION_FILE in version_files
             or JAVASCRIPT_VERSION_FILE in version_files
         ):

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -43,6 +43,7 @@ from reana.config import (
     REPO_LIST_CLUSTER_INFRASTRUCTURE,
     REPO_LIST_CLUSTER_RUNTIME_BATCH,
     REPO_LIST_DEMO_RUNNABLE,
+    REPO_LIST_PYTHON_FIRST,
 )
 
 
@@ -691,7 +692,10 @@ def get_current_component_version_from_source_files(
         all_version_files = {version_file: all_version_files[version_file]}
 
     version = ""
-    if all_version_files.get(DOCKER_VERSION_FILE):
+    if (
+        all_version_files.get(DOCKER_VERSION_FILE)
+        and component not in REPO_LIST_PYTHON_FIRST
+    ):
         with open(all_version_files.get(DOCKER_VERSION_FILE)) as f:
             for line in f.readlines():
                 match = re.match(
@@ -952,7 +956,10 @@ def bump_component_version(
             )
 
     # depending on a component, return proper component version
-    if DOCKER_VERSION_FILE in next_version_per_file_type.keys():
+    if (
+        DOCKER_VERSION_FILE in next_version_per_file_type.keys()
+        and component not in REPO_LIST_PYTHON_FIRST
+    ):
         return next_version_per_file_type[DOCKER_VERSION_FILE], updated_files
     elif HELM_VERSION_FILE in next_version_per_file_type.keys():
         return next_version_per_file_type[HELM_VERSION_FILE], updated_files


### PR DESCRIPTION
The `reana-client` component is released both on PyPI and DockerHub, but it is primarily a Python package. Introduction of `Dockerfile` caused `git-tag` and `git-create-release-commit` commands to use semver2 format (e.g. 0.95.0-alpha.3) instead of the PEP440 format (e.g. 0.95.0a3) expected by PyPI. This change introduces `REPO_LIST_PYTHON_FIRST` configuration variable to treat `reana-client` as a Python package first, ensuring the correct version format for tags and release commits, while still updating `Dockerfile` with semver2 format.