### PR TITLE
ci(python): pin setuptools below 81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -234,7 +234,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install twine wheel
           pip install -e .[all]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+setuptools<81
 -e .[all]

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -643,7 +643,7 @@ def upgrade_requirements(component: str) -> bool:
 
     docker_cmd = (
         f"docker run --rm -it -v {get_srcdir(component)}:/code:z {PYTHON_DOCKER_IMAGE} "
-        f"bash -c 'cd /code && pip install --upgrade pip-tools setuptools pip && {pip_compile_cmd}'"
+        f"bash -c 'cd /code && pip install --upgrade pip-tools pip && pip install \"setuptools<81\" && {pip_compile_cmd}'"
     )
     run_command(docker_cmd, component)
     return True


### PR DESCRIPTION
Pin setuptools<81 in CI workflows, ReadTheDocs
configuration, and reana-dev pip-compile helper. This is
because the recent setuptools 81.0.0 upgrade removed the
pkg_resources module that is needed at runtime by some
dependencies.