### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
-        run: ./run-tests.sh --check-sphinx
+        run: ./run-tests.sh --docs-sphinx
 
   format-black:
     runs-on: ubuntu-24.04
@@ -48,7 +48,7 @@ jobs:
       - name: Check Python code formatting
         run: |
           pip install black
-          ./run-tests.sh --check-black
+          ./run-tests.sh --format-black
 
   format-prettier:
     runs-on: ubuntu-24.04
@@ -62,23 +62,7 @@ jobs:
       - name: Check Prettier code fomatting
         run: |
           npm install prettier --global
-          ./run-tests.sh --check-prettier
-
-  format-pydocstyle:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check compliance with Python docstring conventions
-        run: |
-          pip install pydocstyle
-          ./run-tests.sh --check-pydocstyle
+          ./run-tests.sh --format-prettier
 
   format-shfmt:
     runs-on: ubuntu-24.04
@@ -89,23 +73,7 @@ jobs:
       - name: Check shell script code fomatting
         run: |
           sudo apt-get install shfmt
-          ./run-tests.sh --check-shfmt
-
-  lint-check-manifest:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check Python manifest completeness
-        run: |
-          pip install check-manifest
-          ./run-tests.sh --check-manifest
+          ./run-tests.sh --format-shfmt
 
   lint-commitlint:
     runs-on: ubuntu-24.04
@@ -126,12 +94,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-flake8:
     runs-on: ubuntu-24.04
@@ -148,7 +116,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install flake8
-          ./run-tests.sh --check-flake8
+          ./run-tests.sh --lint-flake8
 
   lint-helm:
     runs-on: ubuntu-24.04
@@ -176,7 +144,23 @@ jobs:
       - name: Lint JSON files
         run: |
           npm install jsonlint --global
-          ./run-tests.sh --check-jsonlint
+          ./run-tests.sh --lint-jsonlint
+
+  lint-manifest:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check Python manifest completeness
+        run: |
+          pip install check-manifest
+          ./run-tests.sh --lint-manifest
 
   lint-markdownlint:
     runs-on: ubuntu-24.04
@@ -190,7 +174,23 @@ jobs:
       - name: Lint Markdown files
         run: |
           npm install markdownlint-cli2 --global
-          ./run-tests.sh --check-markdownlint
+          ./run-tests.sh --lint-markdownlint
+
+  lint-pydocstyle:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check compliance with Python docstring conventions
+        run: |
+          pip install pydocstyle
+          ./run-tests.sh --lint-pydocstyle
 
   lint-shellcheck:
     runs-on: ubuntu-24.04
@@ -201,7 +201,7 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+          ./run-tests.sh --lint-shellcheck
 
   lint-yamllint:
     runs-on: ubuntu-24.04
@@ -219,7 +219,7 @@ jobs:
       - name: Lint YAML files
         run: |
           pip install yamllint
-          ./run-tests.sh --check-yamllint
+          ./run-tests.sh --lint-yamllint
 
   python-tests:
     runs-on: ubuntu-24.04
@@ -239,7 +239,7 @@ jobs:
           pip install -e .[all]
 
       - name: Run pytest
-        run: ./run-tests.sh --check-pytest
+        run: ./run-tests.sh --python-tests
 
       - name: Codecov Coverage
         uses: codecov/codecov-action@v4

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,31 @@
 set -o errexit
 set -o nounset
 
-check_commitlint() {
+docs_sphinx() {
+    sphinx-build -qnNW docs docs/_build/html
+}
+
+format_black() {
+    black --check .
+}
+
+format_prettier() {
+    prettier -c .
+}
+
+format_shfmt() {
+    shfmt -d .
+}
+
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -43,95 +63,102 @@ check_commitlint() {
     fi
 }
 
-check_shellcheck() {
-    find . -name "*.sh" -exec shellcheck {} \+
-}
-
-check_black() {
-    black --check .
-}
-
-check_flake8() {
+lint_flake8() {
     flake8 .
 }
 
-check_pydocstyle() {
-    pydocstyle reana
-}
-
-check_manifest() {
-    check-manifest
-}
-
-check_sphinx() {
-    sphinx-build -qnNW docs docs/_build/html
-}
-
-check_pytest() {
-    pytest
-}
-
-check_helm() {
+lint_helm() {
     helm lint helm/reana
 }
 
-check_yamllint() {
-    yamllint .
-}
-
-check_markdownlint() {
-    markdownlint-cli2 "**/*.md"
-}
-
-check_prettier() {
-    prettier -c .
-}
-
-check_shfmt() {
-    shfmt -d .
-}
-
-check_jsonlint() {
+lint_jsonlint() {
     find . -name "*.json" -exec jsonlint -q {} \+
 }
 
-check_all() {
-    check_commitlint
-    check_shellcheck
-    check_black
-    check_flake8
-    check_pydocstyle
-    check_manifest
-    check_sphinx
-    check_pytest
-    check_helm
-    check_yamllint
-    check_markdownlint
-    check_prettier
-    check_shfmt
-    check_jsonlint
+lint_manifest() {
+    check-manifest
+}
+
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
+lint_pydocstyle() {
+    pydocstyle reana
+}
+
+lint_shellcheck() {
+    find . -name "*.sh" -exec shellcheck {} \+
+}
+
+lint_yamllint() {
+    yamllint .
+}
+
+python_tests() {
+    pytest
+}
+
+all() {
+    docs_sphinx
+    format_black
+    format_prettier
+    format_shfmt
+    lint_commitlint
+    lint_flake8
+    lint_helm
+    lint_jsonlint
+    lint_manifest
+    lint_markdownlint
+    lint_pydocstyle
+    lint_shellcheck
+    lint_yamllint
+    python_tests
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all                Perform all checks [default]"
+    echo "  --docs-sphinx        Check Sphinx docs build"
+    echo "  --format-black       Check formatting of Python code"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
+    echo "  --format-shfmt       Check formatting of shell scripts"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-flake8        Check linting of Python code"
+    echo "  --lint-helm          Check linting of Helm charts"
+    echo "  --lint-jsonlint      Check linting of JSON files"
+    echo "  --lint-manifest      Check linting of Python manifest"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
+    echo "  --lint-pydocstyle    Check linting of Python docstrings"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
+    echo "  --python-tests       Check Python test suite"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
---check-commitlint) check_commitlint "$@" ;;
---check-shellcheck) check_shellcheck ;;
---check-black) check_black ;;
---check-flake8) check_flake8 ;;
---check-pydocstyle) check_pydocstyle ;;
---check-manifest) check_manifest ;;
---check-sphinx) check_sphinx ;;
---check-pytest) check_pytest ;;
---check-helm) check_helm ;;
---check-yamllint) check_yamllint ;;
---check-markdownlint) check_markdownlint ;;
---check-prettier) check_prettier ;;
---check-shfmt) check_shfmt ;;
---check-jsonlint) check_jsonlint ;;
-*) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
+--all) all ;;
+--help) help ;;
+--docs-sphinx) docs_sphinx ;;
+--format-black) format_black ;;
+--format-prettier) format_prettier ;;
+--format-shfmt) format_shfmt ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-flake8) lint_flake8 ;;
+--lint-helm) lint_helm ;;
+--lint-jsonlint) lint_jsonlint ;;
+--lint-manifest) lint_manifest ;;
+--lint-markdownlint) lint_markdownlint ;;
+--lint-pydocstyle) lint_pydocstyle ;;
+--lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
+--python-tests) python_tests ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.