### PR TITLE
feat(helm): remove default GitLab host

### DIFF
--- a/helm/reana/templates/gitlab-secrets.yaml
+++ b/helm/reana/templates/gitlab-secrets.yaml
@@ -9,4 +9,4 @@ type: Opaque
 data:
   REANA_GITLAB_OAUTH_APP_ID: {{ if hasKey .Values.secrets.gitlab "REANA_GITLAB_OAUTH_APP_ID" }}{{ .Values.secrets.gitlab.REANA_GITLAB_OAUTH_APP_ID | b64enc }}{{ else }}{{ "reana_gitlab_oauth_app_id" | b64enc }}{{ end }}
   REANA_GITLAB_OAUTH_APP_SECRET: {{ if hasKey .Values.secrets.gitlab "REANA_GITLAB_OAUTH_APP_SECRET" }}{{ .Values.secrets.gitlab.REANA_GITLAB_OAUTH_APP_SECRET | b64enc }}{{ else }}{{ "reana_gitlab_oauth_app_secret" | b64enc }}{{ end }}
-  REANA_GITLAB_HOST: {{ if hasKey .Values.secrets.gitlab "REANA_GITLAB_HOST" }}{{ .Values.secrets.gitlab.REANA_GITLAB_HOST | b64enc }}{{ else }}{{ "gitlab.cern.ch" | b64enc }}{{ end }}
+  REANA_GITLAB_HOST: "{{ if hasKey .Values.secrets.gitlab "REANA_GITLAB_HOST" }}{{ .Values.secrets.gitlab.REANA_GITLAB_HOST | b64enc }}{{ else }}{{ "" | b64enc }}{{ end }}"


### PR DESCRIPTION
Most REANA deployments are not connected to any GitLab instance. Changes the default value of `REANA_GITLAB_HOST` from `gitlab.cern.ch` to an empty string, so that new deployments start in an unconnected state. Deployments that rely on GitLab integration should set the host explicitly via Helm values.

The template value is now quoted to ensure Helm renders empty strings correctly rather than producing a YAML null.