### PR TITLE
fix(helm): quote Helm template values consistently

### DIFF
--- a/helm/reana/templates/cronjobs.yaml
+++ b/helm/reana/templates/cronjobs.yaml
@@ -39,7 +39,7 @@ spec:
             env:
             {{- if .Values.reana_hostname }}
             - name: REANA_HOSTNAME
-              value: {{ .Values.reana_hostname }}
+              value: {{ .Values.reana_hostname | quote }}
             {{- end }}
             {{- if .Values.debug.enabled }}
             - name: FLASK_ENV
@@ -56,15 +56,15 @@ spec:
                   name: {{ include "reana.prefix" . }}-db-secrets
                   key: password
             - name: REANA_NOTIFICATIONS_ENABLED
-              value: "{{ .Values.notifications.enabled }}"
+              value: {{ .Values.notifications.enabled | quote }}
             - name: REANA_EMAIL_RECEIVER
-              value: {{ .Values.notifications.email_config.receiver }}
+              value: {{ .Values.notifications.email_config.receiver | quote }}
             - name: REANA_EMAIL_SENDER
-              value: {{ .Values.notifications.email_config.sender }}
+              value: {{ .Values.notifications.email_config.sender | quote }}
             - name: REANA_EMAIL_SMTP_SERVER
-              value: {{ .Values.notifications.email_config.smtp_server | default (printf "%s-mail" (include "reana.prefix" .)) }}
+              value: {{ .Values.notifications.email_config.smtp_server | default (printf "%s-mail" (include "reana.prefix" .)) | quote }}
             - name: REANA_EMAIL_SMTP_PORT
-              value: "{{ .Values.notifications.email_config.smtp_port | default "30025" }}"
+              value: {{ .Values.notifications.email_config.smtp_port | default "30025" | quote }}
             - name: REANA_EMAIL_SMTP_SSL
               value: {{ .Values.notifications.email_config.smtp_ssl | quote }}
             {{- if .Values.debug.enabled }}
@@ -97,9 +97,9 @@ spec:
                   name: {{ include "reana.prefix" . }}-secrets
                   key: REANA_SECRET_KEY
             - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Release.Namespace | quote }}
             - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
-              value: {{ .Values.namespace_runtime | default .Release.Namespace }}
+              value: {{ .Values.namespace_runtime | default .Release.Namespace | quote }}
             volumeMounts:
               {{- if .Values.debug.enabled }}
               - mountPath: /code/
@@ -166,7 +166,7 @@ spec:
               value: "true"
             {{- if .Values.reana_hostname }}
             - name: REANA_HOSTNAME
-              value: {{ .Values.reana_hostname }}
+              value: {{ .Values.reana_hostname | quote }}
             {{- end }}
             {{- if .Values.debug.enabled }}
             - name: FLASK_ENV
@@ -185,9 +185,9 @@ spec:
             - name: REANA_COMPONENT_PREFIX
               value: {{ include "reana.prefix" . }}
             - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Release.Namespace | quote }}
             - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
-              value: {{ .Values.namespace_runtime | default .Release.Namespace }}
+              value: {{ .Values.namespace_runtime | default .Release.Namespace | quote }}
             volumeMounts:
               {{- if .Values.debug.enabled }}
               - mountPath: /code/
@@ -250,7 +250,7 @@ spec:
             env:
             {{- if .Values.reana_hostname }}
             - name: REANA_HOSTNAME
-              value: {{ .Values.reana_hostname }}
+              value: {{ .Values.reana_hostname | quote }}
             {{- end }}
             {{- if .Values.debug.enabled }}
             - name: FLASK_ENV
@@ -279,9 +279,9 @@ spec:
                   name: {{ include "reana.prefix" . }}-secrets
                   key: REANA_SECRET_KEY
             - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Release.Namespace | quote }}
             - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
-              value: {{ .Values.namespace_runtime | default .Release.Namespace }}
+              value: {{ .Values.namespace_runtime | default .Release.Namespace | quote }}
             volumeMounts:
               {{- if .Values.debug.enabled }}
               - mountPath: /code/
@@ -345,7 +345,7 @@ spec:
             env:
             {{- if .Values.reana_hostname }}
             - name: REANA_HOSTNAME
-              value: {{ .Values.reana_hostname }}
+              value: {{ .Values.reana_hostname | quote }}
             {{- end }}
             {{- if .Values.debug.enabled }}
             - name: FLASK_ENV
@@ -374,9 +374,9 @@ spec:
                   name: {{ include "reana.prefix" . }}-secrets
                   key: REANA_SECRET_KEY
             - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ .Release.Namespace | quote }}
             - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
-              value: {{ .Values.namespace_runtime | default .Release.Namespace }}
+              value: {{ .Values.namespace_runtime | default .Release.Namespace | quote }}
             volumeMounts:
               {{- if .Values.debug.enabled }}
               - mountPath: /code/

--- a/helm/reana/templates/priority-classes.yaml
+++ b/helm/reana/templates/priority-classes.yaml
@@ -4,7 +4,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ include "reana.prefix" . }}-fluent-bit-priority-class
-value: {{ index .Values "fluent-bit" "priority" | default 1000000 }}
+value: {{ index .Values "fluent-bit" "priority" | default 1000000 | int }}
 preemptionPolicy: Never
 globalDefault: false
 description: "PriorityClass for FluentBit DaemonSet pods. This priority class will not cause other pods to be preempted."

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -90,9 +90,9 @@ spec:
           - name: REANA_COMPUTE_BACKENDS
             value: {{ .Values.compute_backends | toJson | quote }}
           - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
-            value: {{ .Release.Namespace }}
+            value: {{ .Release.Namespace | quote }}
           - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
-            value: {{ .Values.namespace_runtime | default .Release.Namespace }}
+            value: {{ .Values.namespace_runtime | default .Release.Namespace | quote }}
           - name: REANA_DEFAULT_QUOTA_CPU_LIMIT
             value: {{ .Values.quota.default_cpu_limit | default 0 | quote }}
           - name: REANA_DEFAULT_QUOTA_DISK_LIMIT
@@ -107,20 +107,20 @@ spec:
           {{- end }}
           {{- if .Values.kubernetes_jobs_max_user_memory_request }}
           - name: REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST
-            value: {{ .Values.kubernetes_jobs_max_user_memory_request }}
+            value: {{ .Values.kubernetes_jobs_max_user_memory_request | quote }}
           {{- end }}
           {{- if .Values.kubernetes_jobs_max_user_memory_limit }}
           - name: REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT
-            value: {{ .Values.kubernetes_jobs_max_user_memory_limit }}
+            value: {{ .Values.kubernetes_jobs_max_user_memory_limit | quote }}
           {{- end }}
           - name: REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT
-            value: !!str {{ .Values.kubernetes_jobs_max_user_timeout_limit | default 1209600 }}  # 1209600 seconds = 14 days
+            value: {{ .Values.kubernetes_jobs_max_user_timeout_limit | default "1209600" | quote }}  # 1209600 seconds = 14 days
           - name: REANA_INTERACTIVE_SESSION_MAX_INACTIVITY_PERIOD
             value: {{ .Values.interactive_sessions.maximum_inactivity_period | default "forever" | quote }}
           - name: REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS
             value: {{ .Values.interactive_sessions.environments | toJson | quote }}
           - name: REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT
-            value: !!str {{ .Values.kubernetes_jobs_timeout_limit | default 604800 }}  # 604800 seconds = 7 days
+            value: {{ .Values.kubernetes_jobs_timeout_limit | default "604800" | quote }}  # 604800 seconds = 7 days
           {{- if .Values.kubernetes_jobs_cpu_request }}
           - name: REANA_KUBERNETES_JOBS_CPU_REQUEST
             value: {{ .Values.kubernetes_jobs_cpu_request | quote }}
@@ -131,29 +131,29 @@ spec:
           {{- end }}
           {{- if .Values.kubernetes_jobs_memory_request }}
           - name: REANA_KUBERNETES_JOBS_MEMORY_REQUEST
-            value: {{ .Values.kubernetes_jobs_memory_request }}
+            value: {{ .Values.kubernetes_jobs_memory_request | quote }}
           {{- end }}
           - name: REANA_KUBERNETES_JOBS_MEMORY_LIMIT
-            value: {{ .Values.kubernetes_jobs_memory_limit | default "4Gi" }}
+            value: {{ .Values.kubernetes_jobs_memory_limit | default "4Gi" | quote }}
           - name: DASK_ENABLED
             value: {{ .Values.dask.enabled | quote }}
           {{- if .Values.dask.enabled }}
           - name: DASK_AUTOSCALER_ENABLED
             value: {{ .Values.dask.autoscaler_enabled | quote | default "true" }}
           - name: REANA_DASK_CLUSTER_MAX_MEMORY_LIMIT
-            value: {{ .Values.dask.cluster_max_memory_limit | default "16Gi" }}
+            value: {{ .Values.dask.cluster_max_memory_limit | default "16Gi" | quote }}
           - name: REANA_DASK_CLUSTER_DEFAULT_NUMBER_OF_WORKERS
-            value: !!str {{ .Values.dask.cluster_default_number_of_workers | default 2 }}
+            value: {{ .Values.dask.cluster_default_number_of_workers | default "2" | quote }}
           - name: REANA_DASK_CLUSTER_MAX_NUMBER_OF_WORKERS
-            value: !!str {{ .Values.dask.cluster_max_number_of_workers | default 20 }}
+            value: {{ .Values.dask.cluster_max_number_of_workers | default "20" | quote }}
           - name: REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_MEMORY
-            value: {{ .Values.dask.cluster_default_single_worker_memory | default "2Gi" }}
+            value: {{ .Values.dask.cluster_default_single_worker_memory | default "2Gi" | quote }}
           - name: REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_MEMORY
-            value: {{ .Values.dask.cluster_max_single_worker_memory | default "8Gi" }}
+            value: {{ .Values.dask.cluster_max_single_worker_memory | default "8Gi" | quote }}
           - name: REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_THREADS
-            value: !!str {{ .Values.dask.cluster_default_single_worker_threads | default 4 }}
+            value: {{ .Values.dask.cluster_default_single_worker_threads | default "4" | quote }}
           - name: REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_THREADS
-            value: !!str {{ .Values.dask.cluster_max_single_worker_threads | default 8 }}
+            value: {{ .Values.dask.cluster_max_single_worker_threads | default "8" | quote }}
           {{- end }}
           - name: WORKSPACE_PATHS
             value: {{ .Values.workspaces.paths | toJson | quote }}
@@ -161,7 +161,7 @@ spec:
             value: {{ .Values.workspaces.retention_rules.maximum_period | default "forever" | quote }}
           {{- if .Values.quota.enabled }}
           - name: REANA_WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY
-            value: {{ tpl .Values.quota.workflow_termination_update_policy . | default "null" }}
+            value: {{ tpl .Values.quota.workflow_termination_update_policy . | default "null" | quote }}
           {{- end }}
           {{- range $key, $value := .Values.components.reana_server.environment }}
           - name: {{ $key }}
@@ -169,7 +169,7 @@ spec:
           {{- end }}
           {{- if .Values.reana_hostname }}
           - name: REANA_HOSTNAME
-            value: {{ .Values.reana_hostname }}
+            value: {{ .Values.reana_hostname | quote }}
           {{- end }}
           - name: CERN_CONSUMER_KEY
             valueFrom:
@@ -265,16 +265,16 @@ spec:
                 name: {{ include "reana.prefix" . }}-db-secrets
                 key: password
           - name: REANA_NOTIFICATIONS_ENABLED
-            value: "{{ .Values.notifications.enabled }}"
+            value: {{ .Values.notifications.enabled | quote }}
           {{- if .Values.notifications.enabled }}
           - name: REANA_EMAIL_RECEIVER
-            value: {{ .Values.notifications.email_config.receiver }}
+            value: {{ .Values.notifications.email_config.receiver | quote }}
           - name: REANA_EMAIL_SENDER
-            value: {{ .Values.notifications.email_config.sender }}
+            value: {{ .Values.notifications.email_config.sender | quote }}
           - name: REANA_EMAIL_SMTP_SERVER
-            value: {{ .Values.notifications.email_config.smtp_server | default (printf "%s-mail" (include "reana.prefix" .)) }}
+            value: {{ .Values.notifications.email_config.smtp_server | default (printf "%s-mail" (include "reana.prefix" .)) | quote }}
           - name: REANA_EMAIL_SMTP_PORT
-            value: "{{ .Values.notifications.email_config.smtp_port | default "30025" }}"
+            value: {{ .Values.notifications.email_config.smtp_port | default "30025" | quote }}
           - name: REANA_EMAIL_SMTP_SSL
             value: {{ .Values.notifications.email_config.smtp_ssl | quote }}
           {{- if .Values.debug.enabled }}
@@ -313,9 +313,9 @@ spec:
         - name: REANA_COMPONENT_PREFIX
           value: {{ include "reana.prefix" . }}
         - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
-          value: {{ .Release.Namespace }}
+          value: {{ .Release.Namespace | quote }}
         - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
-          value: {{ .Values.namespace_runtime | default .Release.Namespace }}
+          value: {{ .Values.namespace_runtime | default .Release.Namespace | quote }}
         {{- range $key, $value := .Values.components.reana_server.environment }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -107,9 +107,9 @@ spec:
           - name: REANA_COMPONENT_PREFIX
             value: {{ include "reana.prefix" . }}
           - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
-            value: {{ .Release.Namespace }}
+            value: {{ .Release.Namespace | quote }}
           - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
-            value: {{ .Values.namespace_runtime | default .Release.Namespace }}
+            value: {{ .Values.namespace_runtime | default .Release.Namespace | quote }}
           - name: REANA_INGRESS_ANNOTATIONS
             value: {{ .Values.ingress.annotations | toJson | quote }}
           {{- if .Values.ingress.ingress_class_name }}
@@ -117,18 +117,18 @@ spec:
             value: {{ .Values.ingress.ingress_class_name | quote }}
           {{- end }}
           - name: REANA_INGRESS_HOST
-            value: {{ .Values.reana_hostname | default "" | quote  }}
+            value: {{ .Values.reana_hostname | default "" | quote }}
           - name: REANA_DEFAULT_QUOTA_CPU_LIMIT
             value: {{ .Values.quota.default_cpu_limit | default 0 | quote }}
           - name: REANA_DEFAULT_QUOTA_DISK_LIMIT
             value: {{ .Values.quota.default_disk_limit | default 0 | quote }}
           {{- if .Values.quota.enabled }}
           - name: REANA_WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY
-            value: {{ tpl .Values.quota.workflow_termination_update_policy . | default "null" }}
+            value: {{ tpl .Values.quota.workflow_termination_update_policy . | default "null" | quote }}
           {{- end }}
           {{- if .Values.naming_scheme }}
           - name: REANA_COMPONENT_NAMING_SCHEME
-            value: {{ .Values.naming_scheme }}
+            value: {{ .Values.naming_scheme | quote }}
           {{- end }}
           - name: WORKSPACE_PATHS
             value: {{ .Values.workspaces.paths | toJson | quote }}
@@ -144,15 +144,15 @@ spec:
           {{- end }}
           {{- if .Values.node_label_runtimebatch }}
           - name: REANA_RUNTIME_BATCH_KUBERNETES_NODE_LABEL
-            value: {{ .Values.node_label_runtimebatch }}
+            value: {{ .Values.node_label_runtimebatch | quote }}
           {{- end }}
           {{- if .Values.node_label_runtimejobs }}
           - name: REANA_RUNTIME_JOBS_KUBERNETES_NODE_LABEL
-            value: {{ .Values.node_label_runtimejobs }}
+            value: {{ .Values.node_label_runtimejobs | quote }}
           {{- end }}
           {{- if .Values.node_label_runtimesessions }}
           - name: REANA_RUNTIME_SESSIONS_KUBERNETES_NODE_LABEL
-            value: {{ .Values.node_label_runtimesessions }}
+            value: {{ .Values.node_label_runtimesessions | quote }}
           {{- end }}
           {{- if .Values.kubernetes_jobs_max_user_cpu_request }}
           - name: REANA_KUBERNETES_JOBS_MAX_USER_CPU_REQUEST
@@ -164,11 +164,11 @@ spec:
           {{- end }}
           {{- if .Values.kubernetes_jobs_max_user_memory_request }}
           - name: REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST
-            value: {{ .Values.kubernetes_jobs_max_user_memory_request }}
+            value: {{ .Values.kubernetes_jobs_max_user_memory_request | quote }}
           {{- end }}
           {{- if .Values.kubernetes_jobs_max_user_memory_limit }}
           - name: REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT
-            value: {{ .Values.kubernetes_jobs_max_user_memory_limit }}
+            value: {{ .Values.kubernetes_jobs_max_user_memory_limit | quote }}
           {{- end }}
           {{- if .Values.kubernetes_jobs_cpu_request }}
           - name: REANA_KUBERNETES_JOBS_CPU_REQUEST
@@ -180,24 +180,24 @@ spec:
           {{- end }}
           {{- if .Values.kubernetes_jobs_memory_request }}
           - name: REANA_KUBERNETES_JOBS_MEMORY_REQUEST
-            value: {{ .Values.kubernetes_jobs_memory_request }}
+            value: {{ .Values.kubernetes_jobs_memory_request | quote }}
           {{- end }}
           - name: REANA_KUBERNETES_JOBS_MEMORY_LIMIT
-            value: {{ .Values.kubernetes_jobs_memory_limit | default "4Gi" }}
+            value: {{ .Values.kubernetes_jobs_memory_limit | default "4Gi" | quote }}
           - name: REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT
-            value: !!str {{ .Values.kubernetes_jobs_max_user_timeout_limit | default 1209600 }}  # 1209600 seconds = 14 days
+            value: {{ .Values.kubernetes_jobs_max_user_timeout_limit | default "1209600" | quote }}  # 1209600 seconds = 14 days
           - name: REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT
-            value: !!str {{ .Values.kubernetes_jobs_timeout_limit | default 604800 }}  # 604800 seconds = 7 days
+            value: {{ .Values.kubernetes_jobs_timeout_limit | default "604800" | quote }}  # 604800 seconds = 7 days
           - name: REANA_JOB_CONTROLLER_IMAGE
-            value: {{ .Values.components.reana_job_controller.image }}
+            value: {{ .Values.components.reana_job_controller.image | quote }}
           - name: REANA_WORKFLOW_ENGINE_IMAGE_CWL
-            value: {{ .Values.components.reana_workflow_engine_cwl.image }}
+            value: {{ .Values.components.reana_workflow_engine_cwl.image | quote }}
           - name: REANA_WORKFLOW_ENGINE_IMAGE_YADAGE
-            value: {{ .Values.components.reana_workflow_engine_yadage.image }}
+            value: {{ .Values.components.reana_workflow_engine_yadage.image | quote }}
           - name: REANA_WORKFLOW_ENGINE_IMAGE_SERIAL
-            value: {{ .Values.components.reana_workflow_engine_serial.image }}
+            value: {{ .Values.components.reana_workflow_engine_serial.image | quote }}
           - name: REANA_WORKFLOW_ENGINE_IMAGE_SNAKEMAKE
-            value: {{ .Values.components.reana_workflow_engine_snakemake.image }}
+            value: {{ .Values.components.reana_workflow_engine_snakemake.image | quote }}
           # Environment variables for workflow engines
           - name: REANA_WORKFLOW_ENGINE_CWL_ENV_VARS
             value: {{ .Values.components.reana_workflow_engine_cwl.environment | toJson | quote }}
@@ -222,15 +222,15 @@ spec:
           - name: DASK_AUTOSCALER_ENABLED
             value: {{ .Values.dask.autoscaler_enabled | quote | default "true" }}
           - name: REANA_DASK_CLUSTER_MAX_MEMORY_LIMIT
-            value: {{ .Values.dask.cluster_max_memory_limit | default "16Gi" }}
+            value: {{ .Values.dask.cluster_max_memory_limit | default "16Gi" | quote }}
           - name: REANA_DASK_CLUSTER_DEFAULT_NUMBER_OF_WORKERS
-            value: !!str {{ .Values.dask.cluster_default_number_of_workers | default 2 }}
+            value: {{ .Values.dask.cluster_default_number_of_workers | default "2" | quote }}
           - name: REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_MEMORY
-            value: {{ .Values.dask.cluster_default_single_worker_memory | default "2Gi" }}
+            value: {{ .Values.dask.cluster_default_single_worker_memory | default "2Gi" | quote }}
           - name: REANA_DASK_CLUSTER_MAX_SINGLE_WORKER_MEMORY
-            value: {{ .Values.dask.cluster_max_single_worker_memory | default "8Gi" }}
+            value: {{ .Values.dask.cluster_max_single_worker_memory | default "8Gi" | quote }}
           - name: REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_THREADS
-            value: !!str {{ .Values.dask.cluster_default_single_worker_threads | default 4 }}
+            value: {{ .Values.dask.cluster_default_single_worker_threads | default "4" | quote }}
           {{- end }}
           {{- if .Values.reana_hostname }}
           - name: REANA_HOSTNAME
@@ -320,12 +320,12 @@ spec:
         - name: REANA_COMPONENT_PREFIX
           value: {{ include "reana.prefix" . }}
         - name: REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE
-          value: {{ .Release.Namespace }}
+          value: {{ .Release.Namespace | quote }}
         - name: REANA_RUNTIME_KUBERNETES_NAMESPACE
-          value: {{ .Values.namespace_runtime | default .Release.Namespace }}
+          value: {{ .Values.namespace_runtime | default .Release.Namespace | quote }}
         {{- if .Values.quota.enabled }}
         - name: REANA_WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY
-          value: {{ tpl .Values.quota.workflow_termination_update_policy . | default "null" }}
+          value: {{ tpl .Values.quota.workflow_termination_update_policy . | default "null" | quote }}
         {{- end }}
         {{- range $key, $value := .Values.components.reana_workflow_controller.environment }}
         - name: {{ $key }}

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -90,7 +90,7 @@ components:
     enabled: true
     docs_url: https://docs.reana.io
     forum_url: https://forum.reana.io
-    file_preview_size_limit: 5242880 # 5 * 1024**2 = 5 MiB
+    file_preview_size_limit: "5242880" # 5 * 1024**2 = 5 MiB
     imagePullPolicy: IfNotPresent
     image: docker.io/reanahub/reana-ui:0.95.0-alpha.3
   reana_db:


### PR DESCRIPTION
Ensure all environment variable values in Helm templates use the `| quote` filter to prevent YAML parsing issues on older Helm versions (e.g. 3.18) where large numeric values like 1209600 could be misinterpreted as scientific notation (1.209600e+06).

Replace `!!str` with `| quote` for timeout and Dask worker count defaults. Add `| quote` to memory, Dask, namespace, hostname, email, image, node label, and quota policy values that were previously unquoted. Add `| int` to the PriorityClass value to ensure integer rendering. Quote the large numeric `file_preview_size_limit` default in values.yaml.