### PR TITLE
fix(helm): use alpha image tag for dask operator

### DIFF
--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -139,7 +139,7 @@ components:
     image: docker.io/reanahub/reana-workflow-engine-snakemake:0.95.0-alpha.4
     environment: {}
   reana_workflow_validator:
-    image: docker.io/reanahub/reana-workflow-validator:0.95.0
+    image: docker.io/reanahub/reana-workflow-validator:0.95.0-alpha.1
     environment: {}
   reana_job_controller:
     image: docker.io/reanahub/reana-job-controller:0.95.0-alpha.4
@@ -208,7 +208,7 @@ dask:
 dask-kubernetes-operator:
   image:
     name: docker.io/reanahub/reana-dask-kubernetes-operator
-    tag: 0.95.0
+    tag: 0.95.0-alpha.2
   serviceAccount:
     create: false
     # Change the reana prefix if you opted another prefix in your cluster

--- a/scripts/prefetch-images.sh
+++ b/scripts/prefetch-images.sh
@@ -26,6 +26,7 @@ for image in \
     docker.io/reanahub/reana-workflow-engine-serial:0.95.0-alpha.4 \
     docker.io/reanahub/reana-workflow-engine-snakemake:0.95.0-alpha.4 \
     docker.io/reanahub/reana-workflow-engine-yadage:0.95.0-alpha.4 \
+    docker.io/reanahub/reana-dask-kubernetes-operator:0.95.0-alpha.2 \
     quay.io/jupyter/scipy-notebook:notebook-7.2.2; do
     docker pull $image
     if [ "$kubernetes" == "kind" ]; then


### PR DESCRIPTION
Also updates the unreleased reana-workflow-validator component to use an alpha tag for consistency.