### PR TITLE
feat(helm): replace FLASK_ENV with FLASK_DEBUG for debug mode

### DIFF
--- a/helm/reana/templates/cronjobs.yaml
+++ b/helm/reana/templates/cronjobs.yaml
@@ -42,8 +42,8 @@ spec:
               value: {{ .Values.reana_hostname | quote }}
             {{- end }}
             {{- if .Values.debug.enabled }}
-            - name: FLASK_ENV
-              value:  "development"
+            - name: FLASK_DEBUG
+              value:  "1"
             {{- end }}
             - name: REANA_DB_USERNAME
               valueFrom:
@@ -169,8 +169,8 @@ spec:
               value: {{ .Values.reana_hostname | quote }}
             {{- end }}
             {{- if .Values.debug.enabled }}
-            - name: FLASK_ENV
-              value:  "development"
+            - name: FLASK_DEBUG
+              value:  "1"
             {{- end }}
             - name: REANA_DB_USERNAME
               valueFrom:
@@ -253,8 +253,8 @@ spec:
               value: {{ .Values.reana_hostname | quote }}
             {{- end }}
             {{- if .Values.debug.enabled }}
-            - name: FLASK_ENV
-              value:  "development"
+            - name: FLASK_DEBUG
+              value:  "1"
             {{- end }}
             - name: REANA_DB_USERNAME
               valueFrom:
@@ -348,8 +348,8 @@ spec:
               value: {{ .Values.reana_hostname | quote }}
             {{- end }}
             {{- if .Values.debug.enabled }}
-            - name: FLASK_ENV
-              value:  "development"
+            - name: FLASK_DEBUG
+              value:  "1"
             {{- end }}
             - name: REANA_DB_USERNAME
               valueFrom:

--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -246,8 +246,8 @@ spec:
             value: "{{ include "reana.prefix" . }}-wdb"
           - name: WDB_NO_BROWSER_AUTO_OPEN
             value: "True"
-          - name: FLASK_ENV
-            value:  "development"
+          - name: FLASK_DEBUG
+            value:  "1"
           # Hack to not verify SSL connections https://stackoverflow.com/questions/48391750/disable-python-requests-ssl-validation-for-an-imported-module
           - name: CURL_CA_BUNDLE
             value: ""
@@ -331,8 +331,8 @@ spec:
           value: "{{ include "reana.prefix" . }}-wdb"
         - name: WDB_NO_BROWSER_AUTO_OPEN
           value: "True"
-        - name: FLASK_ENV
-          value:  "development"
+        - name: FLASK_DEBUG
+          value:  "1"
         # Hack to not verify SSL connections https://stackoverflow.com/questions/48391750/disable-python-requests-ssl-validation-for-an-imported-module
         - name: CURL_CA_BUNDLE
           value: ""

--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -263,8 +263,8 @@ spec:
             value: "{{ include "reana.prefix" . }}-wdb"
           - name: WDB_NO_BROWSER_AUTO_OPEN
             value: "True"
-          - name: FLASK_ENV
-            value:  "development"
+          - name: FLASK_DEBUG
+            value:  "1"
           # Hack to not verify SSL connections https://stackoverflow.com/questions/48391750/disable-python-requests-ssl-validation-for-an-imported-module
           - name: CURL_CA_BUNDLE
             value: ""
@@ -344,8 +344,8 @@ spec:
           value: "{{ include "reana.prefix" . }}-wdb"
         - name: WDB_NO_BROWSER_AUTO_OPEN
           value: "True"
-        - name: FLASK_ENV
-          value:  "development"
+        - name: FLASK_DEBUG
+          value:  "1"
         # Hack to not verify SSL connections https://stackoverflow.com/questions/48391750/disable-python-requests-ssl-validation-for-an-imported-module
         - name: CURL_CA_BUNDLE
           value: ""

--- a/reana/reana_dev/client.py
+++ b/reana/reana_dev/client.py
@@ -11,13 +11,15 @@
 import base64
 import json
 import logging
+import os
 import subprocess
+import sys
 import traceback
 
 import click
 
 from reana.config import REPO_LIST_CLIENT
-from reana.reana_dev.utils import run_command
+from reana.reana_dev.utils import get_srcdir, run_command
 
 
 @click.group()
@@ -27,12 +29,30 @@ def client_commands():
 
 @client_commands.command(name="client-install")
 def client_install():  # noqa: D301
-    """Install latest REANA client and its dependencies."""
+    """Install latest REANA client and its dependencies.
+
+    All components are installed in a single pip invocation so that
+    pip can resolve version constraints from all local source
+    directories together, avoiding conflicts when local branches
+    have different dependency pins than published PyPI versions.
+    """
+    paths = []
     for component in REPO_LIST_CLIENT:
-        for cmd in [
-            "if [ -e setup.py ] || [ -e pyproject.toml ]; then pip install . --upgrade; fi",
-        ]:
-            run_command(cmd, component)
+        srcdir = get_srcdir(component)
+        if not os.path.isdir(srcdir):
+            click.secho(
+                f"[ERROR] Expected client component '{component}' is not "
+                f"checked out at {srcdir}.",
+                fg="red",
+            )
+            sys.exit(1)
+        if os.path.exists(os.path.join(srcdir, "setup.py")) or os.path.exists(
+            os.path.join(srcdir, "pyproject.toml")
+        ):
+            paths.append(srcdir)
+    if paths:
+        cmd = "pip install --upgrade " + " ".join(paths)
+        run_command(cmd, "reana")
     run_command("pip check", "reana")
 
 

--- a/reana/reana_dev/python.py
+++ b/reana/reana_dev/python.py
@@ -180,7 +180,7 @@ def python_unit_tests(
                 ),
                 # Now we can call installing regular test dependencies
                 '{} && pip install ".[tests]" --upgrade'.format(cmd_activate_venv),
-                "{} && {} ./run-tests.sh --check-pytest".format(
+                "{} && {} ./run-tests.sh --python-tests".format(
                     cmd_activate_venv, env_pytestarg
                 ),
             ]:


### PR DESCRIPTION
-   feat(helm): replace FLASK_ENV with FLASK_DEBUG for debug mode

    The FLASK_ENV environment variable was deprecated in Flask 2.3
    and removed in Flask 3.x. With the upgrade of REANA components
    to Flask 3.x, replace all FLASK_ENV=development settings in the
    Helm templates with the equivalent FLASK_DEBUG=1 across the
    reana-server, reana-workflow-controller, and cronjob deployments.

-   fix(reana-dev): install all client components in one pip call

    Previously, `reana-dev client-install` installed components
    one-by-one in sequence. This caused dependency resolution
    issues when local branches had different version pins than
    the published PyPI packages: earlier installs would lock in
    versions from PyPI that later installs could not override.

    Install all components in a single `pip install` command so
    that pip resolves constraints from all local source directories
    together, picking compatible versions across the board.

Closes reanahub/reana-server#770.