### PR TITLE
refactor(pytest): drop pytest-reana and use pytest directly

### DIFF
--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -17,7 +17,6 @@ sources:
   - https://github.com/reanahub/reana-job-controller
   - https://github.com/reanahub/reana-commons
   - https://github.com/reanahub/reana-db
-  - https://github.com/reanahub/pytest-reana
   - https://github.com/reanahub/www.reana.io
 keywords:
   - research-data

--- a/reana/config.py
+++ b/reana/config.py
@@ -53,7 +53,6 @@ REPO_LIST_ALL = [
     "reana-env-root6",
     "reana-github-actions",
     "reana-job-controller",
-    "pytest-reana",
     "reana-message-broker",
     "reana-server",
     "reana-ui",
@@ -70,7 +69,6 @@ REPO_LIST_ALL = [
 
 REPO_LIST_CLIENT = [
     # shared utils
-    "pytest-reana",
     "reana-commons",
     "reana-db",
     # client
@@ -106,8 +104,6 @@ REPO_LIST_SHARED = [
 
 REPO_LIST_CLUSTER = (
     [
-        # shared utils
-        "pytest-reana",
         # cluster helpers
         "reana-auth-krb5",
         "reana-auth-rucio",

--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -991,8 +991,8 @@ def git_checkout_pr(branch, issue, fetch, pull, reset):  # noqa: D301
     :param issue: Derive PRs to check out from the cross-references of a GitHub
                   issue. The value consists of two strings: the reanahub
                   repository name and the issue number. For example,
-                  ``-i pytest-reana 156`` will check out all PRs that
-                  reference the pytest-reana#156 issue.
+                  ``-i reana-commons 123`` will check out all PRs that
+                  reference the reana-commons#123 issue.
     :param fetch: Fetch latest upstream before checking out? [default=False]
     :param pull: Fetch and fast-forward existing local PR branches? [default=False]
     :param reset: Fetch and hard-reset existing local PR branches? [default=False]

--- a/reana/reana_dev/python.py
+++ b/reana/reana_dev/python.py
@@ -154,8 +154,6 @@ def python_unit_tests(
                 ),
                 "{} && which python".format(cmd_activate_venv),
                 "{} && pip install pip --upgrade".format(cmd_activate_venv),
-                "{} && cd ../pytest-reana && "
-                " pip install . --upgrade".format(cmd_activate_venv),
                 "{} && cd ../reana-commons && "
                 " pip install . --upgrade".format(cmd_activate_venv),
                 "{} && cd ../reana-db && "

--- a/reana/reana_dev/wiki.py
+++ b/reana/reana_dev/wiki.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2022, 2024, 2025 CERN.
+# Copyright (C) 2020, 2021, 2022, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -59,7 +59,7 @@ def create_build_status_page():
         "developers": {
             "title": "For developers",
             "description": "Understand REANA source code, adapt it to your needs, contribute changes back.",
-            "packages": {"reana": {}, "pytest-reana": {}},
+            "packages": {"reana": {}},
         },
         "environments": {
             "simple": True,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ extras_require = {
         "Sphinx>=1.5.1",
     ],
     "tests": [
-        "pytest-reana>=0.9.2,<0.10.0",
+        "pytest>=7.0.0,<9.0.0",
+        "pytest-cov>=3.0.0,<4.0",
+        "mock>=3.0,<4",
     ],
     "benchmark": [
         "pandas>=1.1.5",


### PR DESCRIPTION
Remove `pytest-reana` from `extras_require[tests]` in `setup.py`, replacing it with direct `pytest`, `pytest-cov` and `mock` dependencies (previously pulled in transitively via `pytest-reana`).

Also remove `pytest-reana` from the repository list in the `reana-dev` helper script configuration, from the various `pip install` steps and the wiki generator's package map, etc.

The `pytest-reana` package is no longer necessary since its fixtures have been split between `reana-commons[tests]` and `reana-db[tests]`.