### PR TITLE
feat(helm): add controller uWSGI ConfigMaps

### DIFF
--- a/helm/reana/templates/reana-server.yaml
+++ b/helm/reana/templates/reana-server.yaml
@@ -39,6 +39,7 @@ spec:
         checksum/app-secrets: {{ include (print $.Template.BasePath "/app-secrets.yaml") . | sha256sum }}
         checksum/cache-secrets: {{ include (print $.Template.BasePath "/cache-secrets.yaml") . | sha256sum }}
         checksum/message-broker-secrets: {{ include (print $.Template.BasePath "/message-broker-secrets.yaml") . | sha256sum }}
+        checksum/uwsgi-config: {{ include (print $.Template.BasePath "/uwsgi-config-reana-server.yaml") . | sha256sum }}
         {{- if .Values.notifications.enabled }}
         checksum/mail-notification-secrets: {{ include (print $.Template.BasePath "/mail-notification-secrets.yaml") . | sha256sum }}
         {{- end }}
@@ -77,7 +78,7 @@ spec:
             mountPath: {{ $workspace_path._1 }}
           {{- end }}
           {{- end }}
-          - name: uwsgi-config
+          - name: uwsgi-config-reana-server
             mountPath: '/var/reana/uwsgi'
           - name: reana-config
             mountPath: '/var/reana/config'
@@ -400,10 +401,10 @@ spec:
         hostPath:
           path: /code/reana-server
       {{- end }}
-      - name: uwsgi-config
+      - name: uwsgi-config-reana-server
         configMap:
           defaultMode: 420
-          name: uwsgi-config
+          name: uwsgi-config-reana-server
       - name: reana-config
         configMap:
           defaultMode: 420

--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -57,6 +57,7 @@ spec:
         checksum/gitlab-secrets: {{ include (print $.Template.BasePath "/gitlab-secrets.yaml") . | sha256sum }}
         checksum/app-secrets: {{ include (print $.Template.BasePath "/app-secrets.yaml") . | sha256sum }}
         checksum/message-broker-secrets: {{ include (print $.Template.BasePath "/message-broker-secrets.yaml") . | sha256sum }}
+        checksum/uwsgi-config: {{ include (print $.Template.BasePath "/uwsgi-config-reana-workflow-controller.yaml") . | sha256sum }}
         {{- if $opensearchEnabled }}
         checksum/opensearch-secrets: {{ include (print $.Template.BasePath "/opensearch-secrets.yaml") . | sha256sum }}
         {{- end }}
@@ -77,6 +78,9 @@ spec:
         args: ["flask run --host=0.0.0.0"]
         tty: true
         stdin: true
+        {{- else }}
+        # do not use "/bin/sh -c" here as that breaks signal propagation
+        command: ["uwsgi", "--ini", "/var/reana/uwsgi/uwsgi.ini"]
         {{- end }}
         volumeMounts:
           {{- if .Values.debug.enabled }}
@@ -85,6 +89,8 @@ spec:
           {{- end }}
           - mountPath: {{ .Values.shared_storage.shared_volume_mount_path }}
             name: reana-shared-volume
+          - name: uwsgi-config-reana-workflow-controller
+            mountPath: '/var/reana/uwsgi'
           {{- range $workspace_paths := .Values.workspaces.paths }}
           {{- if ne (typeOf $workspace_paths) "string" -}}
           {{- fail "The workspaces.paths should be a list of strings e.g node_host_path:pod_mount_path" -}}
@@ -410,6 +416,10 @@ spec:
             - key: ca.crt
               path: ca.crt
       {{- end }}
+      - name: uwsgi-config-reana-workflow-controller
+        configMap:
+          defaultMode: 420
+          name: uwsgi-config-reana-workflow-controller
       {{- if .Values.debug.enabled }}
       - name: reana-code
         hostPath:

--- a/helm/reana/templates/uwsgi-config-reana-job-controller.yaml
+++ b/helm/reana/templates/uwsgi-config-reana-job-controller.yaml
@@ -1,0 +1,56 @@
+{{- $namespaces := list .Release.Namespace }}
+{{- if and .Values.namespace_runtime (ne .Values.namespace_runtime .Release.Namespace) }}
+{{- $namespaces = append $namespaces .Values.namespace_runtime }}
+{{- end }}
+{{- range $namespaces }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uwsgi-config-reana-job-controller
+  namespace: {{ . }}
+data:
+  uwsgi.ini: |
+    [uwsgi]
+    stats = /tmp/stats.socket
+    http = 0.0.0.0:5000
+    module = reana_job_controller.app:app
+    master = true
+    processes = 1
+    threads = {{ $.Values.components.reana_job_controller.uwsgi.threads }}
+    enable-threads = true
+    single-interpreter = true
+    need-app = true
+    vacuum = true
+    wsgi-disable-file-wrapper = true
+
+    auto-procname = true
+    buffer-size = 10240
+    post-buffering = true
+    lazy-apps = true
+
+    # Logging
+    {{- if not $.Values.components.reana_job_controller.uwsgi.log_all }}
+    disable-logging = true
+    log-4xx = {{ $.Values.components.reana_job_controller.uwsgi.log_4xx }}
+    log-5xx = {{ $.Values.components.reana_job_controller.uwsgi.log_5xx }}
+    {{- end }}
+
+    # Workers management
+    idle = {{ $.Values.components.reana_job_controller.uwsgi.idle }}
+    max-requests = {{ $.Values.components.reana_job_controller.uwsgi.max_requests }}
+    max-requests-delta = 149
+    max-worker-lifetime = {{ $.Values.components.reana_job_controller.uwsgi.max_worker_lifetime }}
+    reload-on-rss = {{ $.Values.components.reana_job_controller.uwsgi.reload_on_rss }}
+
+    # fix up signal handling
+    die-on-term = true
+    hook-master-start = unix_signal:2 gracefully_kill_them_all
+    hook-master-start = unix_signal:15 gracefully_kill_them_all
+
+    # enable keepalive to avoid 500/502 from traefik
+    http-keepalive = 1
+
+    # fix uWSGI memory consumption on systems with very high fs.nr_open limits
+    max-fd = 1048576
+{{- end }}

--- a/helm/reana/templates/uwsgi-config-reana-server.yaml
+++ b/helm/reana/templates/uwsgi-config-reana-server.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: uwsgi-config
+  name: uwsgi-config-reana-server
   namespace: {{ .Release.Namespace }}
 data:
   uwsgi.ini: |
@@ -34,10 +34,11 @@ data:
     {{- end }}
 
     # Workers management
-    max-requests = 1999
+    idle = {{ .Values.components.reana_server.uwsgi.idle }}
+    max-requests = {{ .Values.components.reana_server.uwsgi.max_requests }}
     max-requests-delta = 149
-    # max-worker-lifetime = 3600 # https://github.com/unbit/uwsgi/issues/1894
-    reload-on-rss = 250
+    max-worker-lifetime = {{ .Values.components.reana_server.uwsgi.max_worker_lifetime }}
+    reload-on-rss = {{ .Values.components.reana_server.uwsgi.reload_on_rss }}
 
     # fix up signal handling
     die-on-term = true

--- a/helm/reana/templates/uwsgi-config-reana-workflow-controller.yaml
+++ b/helm/reana/templates/uwsgi-config-reana-workflow-controller.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uwsgi-config-reana-workflow-controller
+  namespace: {{ .Release.Namespace }}
+data:
+  uwsgi.ini: |
+    [uwsgi]
+    stats = /tmp/stats.socket
+    http = 0.0.0.0:5000
+    module = reana_workflow_controller.app:app
+    master = true
+    processes = {{ .Values.components.reana_workflow_controller.uwsgi.processes }}
+    threads = {{ .Values.components.reana_workflow_controller.uwsgi.threads }}
+    enable-threads = true
+    single-interpreter = true
+    need-app = true
+    vacuum = true
+    wsgi-disable-file-wrapper = true
+
+    auto-procname = true
+    buffer-size = 10240
+    post-buffering = true
+    lazy-apps = true
+
+    # Logging
+    {{- if not .Values.components.reana_workflow_controller.uwsgi.log_all }}
+    disable-logging = true
+    log-4xx = {{ .Values.components.reana_workflow_controller.uwsgi.log_4xx }}
+    log-5xx = {{ .Values.components.reana_workflow_controller.uwsgi.log_5xx }}
+    {{- end }}
+
+    # Workers management
+    idle = {{ .Values.components.reana_workflow_controller.uwsgi.idle }}
+    max-requests = {{ .Values.components.reana_workflow_controller.uwsgi.max_requests }}
+    max-requests-delta = 149
+    max-worker-lifetime = {{ .Values.components.reana_workflow_controller.uwsgi.max_worker_lifetime }}
+    reload-on-rss = {{ .Values.components.reana_workflow_controller.uwsgi.reload_on_rss }}
+
+    # fix up signal handling
+    die-on-term = true
+    hook-master-start = unix_signal:2 gracefully_kill_them_all
+    hook-master-start = unix_signal:15 gracefully_kill_them_all
+
+    # enable keepalive to avoid 500/502 from traefik
+    http-keepalive = 1
+
+    # fix uWSGI memory consumption on systems with very high fs.nr_open limits
+    max-fd = 1048576

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -123,6 +123,10 @@ components:
       log_all: true
       log_4xx: true
       log_5xx: true
+      idle: 0
+      max_requests: 1999
+      max_worker_lifetime: 0
+      reload_on_rss: 250
   reana_workflow_controller:
     imagePullPolicy: IfNotPresent
     image: docker.io/reanahub/reana-workflow-controller:0.95.0-alpha.7
@@ -132,6 +136,16 @@ components:
       REANA_OPENSEARCH_ENABLED: false
       REANA_OPENSEARCH_USE_SSL: true
       REANA_OPENSEARCH_CA_CERTS: "/code/certs/ca.crt"
+    uwsgi:
+      processes: 2
+      threads: 2
+      log_all: true
+      log_4xx: true
+      log_5xx: true
+      idle: 0
+      max_requests: 1999
+      max_worker_lifetime: 0
+      reload_on_rss: 1024
   reana_workflow_engine_cwl:
     image: docker.io/reanahub/reana-workflow-engine-cwl:0.95.0-alpha.5
     environment: {}
@@ -150,6 +164,15 @@ components:
   reana_job_controller:
     image: docker.io/reanahub/reana-job-controller:0.95.0-alpha.5
     environment: {}
+    uwsgi:
+      threads: 2
+      log_all: true
+      log_4xx: true
+      log_5xx: true
+      idle: 0
+      max_requests: 1999
+      max_worker_lifetime: 0
+      reload_on_rss: 250
   reana_message_broker:
     imagePullPolicy: IfNotPresent
     image: docker.io/reanahub/reana-message-broker:0.95.0-alpha.3


### PR DESCRIPTION
Add Helm-managed uWSGI ConfigMaps for reana-workflow-controller and
reana-job-controller.

Mount the workflow-controller configuration in its deployment and use it
for production startup. Create the job-controller configuration in both
infrastructure and runtime namespaces so that run-batch pods can mount
it.

Expose controller uWSGI worker, logging, recycling, and memory settings
through chart values. Rename the existing reana-server configuration
template to distinguish the three component-specific ConfigMaps.

Supports reanahub/reana-workflow-controller#683 and
reanahub/reana-job-controller#517.

Closes reanahub/reana#952
