### PR TITLE
feat(reana-dev): add create-branch option to git-upgrade command

### DIFF
--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -1163,20 +1163,26 @@ def git_upgrade(component, exclude_components, create_branch, base):  # noqa: D3
         if not branch_exists(component, base):
             if create_branch:
                 # Check if upstream branch exists before creating local branch
-                cmd = f"git ls-remote --heads upstream refs/heads/{base}"
-                if not run_command(cmd, component, display=False, return_output=True):
+                if not run_command(
+                    ["git", "ls-remote", "--heads", "upstream", f"refs/heads/{base}"],
+                    component,
+                    display=False,
+                    return_output=True,
+                ):
                     display_message(
                         f"Branch {base} does not exist in upstream, skipping.",
                         component=component,
                     )
                     continue
 
-                run_command("git fetch upstream", component)
-                run_command(f"git checkout -b {base} upstream/{base}", component)
+                run_command(["git", "fetch", "upstream"], component)
+                run_command(
+                    ["git", "checkout", "-b", base, f"upstream/{base}"], component
+                )
                 try:
-                    run_command(f"git push -u origin {base}", component)
+                    run_command(["git", "push", "-u", "origin", base], component)
                 finally:
-                    run_command("git checkout -", component)
+                    run_command(["git", "checkout", "-"], component)
                 display_message(
                     f"Branch {base} created from upstream and pushed to origin.",
                     component=component,
@@ -1189,11 +1195,11 @@ def git_upgrade(component, exclude_components, create_branch, base):  # noqa: D3
             # Branch was just created fresh or is missing so skip the merge/push upgrade flow
             continue
 
-        run_command("git fetch upstream", component)
-        run_command(f"git checkout {base}", component)
-        run_command(f"git merge --ff-only upstream/{base}", component)
-        run_command(f"git push origin {base}", component)
-        run_command("git checkout -", component)
+        run_command(["git", "fetch", "upstream"], component)
+        run_command(["git", "checkout", base], component)
+        run_command(["git", "merge", "--ff-only", f"upstream/{base}"], component)
+        run_command(["git", "push", "origin", base], component)
+        run_command(["git", "checkout", "-"], component)
 
 
 @click.argument("range", default="")

--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -1120,9 +1120,15 @@ def git_fetch(component, exclude_components):  # noqa: D301
     default="",
     help="Which components to exclude? [c1,c2,c3]",
 )
+@click.option(
+    "--create-branch",
+    is_flag=True,
+    default=False,
+    help="Should the branch be created if it does not exist? [default=False]",
+)
 @git_commands.command(name="git-upgrade")
 @click_add_git_base_branch_option
-def git_upgrade(component, exclude_components, base):  # noqa: D301
+def git_upgrade(component, exclude_components, create_branch, base):  # noqa: D301
     """Upgrade REANA local source code repositories and push to GitHub origin.
 
     \b
@@ -1142,28 +1148,52 @@ def git_upgrade(component, exclude_components, base):  # noqa: D301
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
     :param exclude_components: List of components to exclude.
+    :param create_branch: Should the branch be created if it does not exist?
     :param base: Against which git base branch are we working on? [default=master]
     :type component: str
     :type exclude_components: str
+    :type create_branch: bool
     :type base: str
     """
     if exclude_components:
         exclude_components = exclude_components.split(",")
+
     components = select_components(component, exclude_components)
     for component in components:
         if not branch_exists(component, base):
-            display_message(
-                "Missing branch {}, skipping.".format(base), component=component
-            )
+            if create_branch:
+                # Check if upstream branch exists before creating local branch
+                cmd = f"git ls-remote --heads upstream refs/heads/{base}"
+                if not run_command(cmd, component, display=False, return_output=True):
+                    display_message(
+                        f"Branch {base} does not exist in upstream, skipping.",
+                        component=component,
+                    )
+                    continue
+
+                run_command("git fetch upstream", component)
+                run_command(f"git checkout -b {base} upstream/{base}", component)
+                try:
+                    run_command(f"git push -u origin {base}", component)
+                finally:
+                    run_command("git checkout -", component)
+                display_message(
+                    f"Branch {base} created from upstream and pushed to origin.",
+                    component=component,
+                )
+            else:
+                display_message(
+                    f"Missing branch {base}, skipping.", component=component
+                )
+
+            # Branch was just created fresh or is missing so skip the merge/push upgrade flow
             continue
-        for cmd in [
-            "git fetch upstream",
-            "git checkout {0}".format(base),
-            "git merge --ff-only upstream/{0}".format(base),
-            "git push origin {0}".format(base),
-            "git checkout -",
-        ]:
-            run_command(cmd, component)
+
+        run_command("git fetch upstream", component)
+        run_command(f"git checkout {base}", component)
+        run_command(f"git merge --ff-only upstream/{base}", component)
+        run_command(f"git push origin {base}", component)
+        run_command("git checkout -", component)
 
 
 @click.argument("range", default="")

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -14,11 +14,12 @@ import importlib.util
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 from concurrent import futures
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import click
 import semver
@@ -335,7 +336,7 @@ def is_component_runnable_example(component):
 
 
 def run_command(
-    cmd: str,
+    cmd: Union[str, Sequence[str]],
     component: str = "",
     display: bool = True,
     return_output: bool = False,
@@ -347,24 +348,27 @@ def run_command(
 
     Exit in case of troubles.
 
-    :param cmd: shell command to run
+    :param cmd: shell command string or argument list; lists are executed
+        without a shell to avoid interpolation of metacharacters
     :param component: standard component name
     :param display: should we display command to run?
     :param return_output: shall the output of the command be returned?
     :param directory: directory where to run the command
     :param dry_run: should we only show the command without executing it?
-    :type cmd: str
+    :type cmd: str or list
     :type component: str
     :type display: bool
     :type return_output: bool
     :type directory: str
     :type dry_run: bool
     """
+    use_shell = isinstance(cmd, str)
+    display_cmd = cmd if use_shell else shlex.join(cmd)
     now = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
     if display:
         click.secho("[{0}] ".format(now), bold=True, nl=False, fg="green")
         click.secho("{0}: ".format(component), bold=True, nl=False, fg="yellow")
-        click.secho("{0}".format(cmd), bold=True)
+        click.secho("{0}".format(display_cmd), bold=True)
     if dry_run:
         return
     if component and directory:
@@ -373,10 +377,10 @@ def run_command(
         os.chdir(get_srcdir(component))
     try:
         if return_output:
-            result = subprocess.check_output(cmd, shell=True)
+            result = subprocess.check_output(cmd, shell=use_shell)
             return result.decode().rstrip("\r\n")
         else:
-            subprocess.check_call(cmd, shell=True)
+            subprocess.check_call(cmd, shell=use_shell)
     except subprocess.CalledProcessError as err:
         if display:
             click.secho("[{0}] ".format(now), bold=True, nl=False, fg="green")

--- a/tests/test_git_upgrade.py
+++ b/tests/test_git_upgrade.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Regression tests for the git-upgrade command."""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from reana.reana_dev.cli import reana_dev
+
+COMPONENT = "reana-server"
+BASE = "maint-1.2"
+
+
+def _invoke(base=BASE, create_branch=False):
+    args = ["git-upgrade", "--base", base, "-c", COMPONENT]
+    if create_branch:
+        args.append("--create-branch")
+    return CliRunner().invoke(reana_dev, args)
+
+
+def _ls_remote_returns(output):
+    """Return a run_command side_effect that answers ls-remote calls with *output*."""
+
+    def side_effect(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and "ls-remote" in cmd:
+            return output
+        return None
+
+    return side_effect
+
+
+@patch("reana.reana_dev.git.display_message")
+@patch("reana.reana_dev.git.branch_exists", return_value=False)
+@patch("reana.reana_dev.git.select_components", return_value=[COMPONENT])
+@patch("reana.reana_dev.git.run_command")
+def test_create_branch_exact_upstream(mock_run, mock_select, mock_exists, mock_display):
+    """Branch is created when the upstream ref matches exactly."""
+    mock_run.side_effect = _ls_remote_returns(f"abc123\trefs/heads/{BASE}")
+
+    result = _invoke(create_branch=True)
+
+    assert result.exit_code == 0
+    mock_run.assert_any_call(
+        ["git", "ls-remote", "--heads", "upstream", f"refs/heads/{BASE}"],
+        COMPONENT,
+        display=False,
+        return_output=True,
+    )
+    mock_run.assert_any_call(
+        ["git", "checkout", "-b", BASE, f"upstream/{BASE}"], COMPONENT
+    )
+    mock_run.assert_any_call(["git", "push", "-u", "origin", BASE], COMPONENT)
+    mock_run.assert_any_call(["git", "checkout", "-"], COMPONENT)
+
+
+@patch("reana.reana_dev.git.display_message")
+@patch("reana.reana_dev.git.branch_exists", return_value=False)
+@patch("reana.reana_dev.git.select_components", return_value=[COMPONENT])
+@patch("reana.reana_dev.git.run_command")
+def test_missing_upstream_branch_skipped(
+    mock_run, mock_select, mock_exists, mock_display
+):
+    """Component is skipped with a message when the base branch is absent from upstream."""
+    mock_run.side_effect = _ls_remote_returns("")
+
+    result = _invoke(create_branch=True)
+
+    assert result.exit_code == 0
+    mock_display.assert_called_once_with(
+        f"Branch {BASE} does not exist in upstream, skipping.",
+        component=COMPONENT,
+    )
+    called_cmds = [c.args[0] for c in mock_run.call_args_list]
+    assert ["git", "fetch", "upstream"] not in called_cmds
+
+
+@patch("reana.reana_dev.git.display_message")
+@patch("reana.reana_dev.git.branch_exists", return_value=False)
+@patch("reana.reana_dev.git.select_components", return_value=[COMPONENT])
+@patch("reana.reana_dev.git.run_command")
+def test_failed_push_restores_original_branch(
+    mock_run, mock_select, mock_exists, mock_display
+):
+    """git checkout - runs in the finally block even when origin push is rejected."""
+
+    def side_effect(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and "ls-remote" in cmd:
+            return f"abc123\trefs/heads/{BASE}"
+        if isinstance(cmd, list) and cmd[:3] == ["git", "push", "-u"]:
+            raise SystemExit(1)
+        return None
+
+    mock_run.side_effect = side_effect
+
+    result = _invoke(create_branch=True)
+
+    assert result.exit_code != 0
+    called_cmds = [c.args[0] for c in mock_run.call_args_list]
+    assert ["git", "checkout", "-"] in called_cmds
+    push_idx = next(
+        i
+        for i, c in enumerate(called_cmds)
+        if c == ["git", "push", "-u", "origin", BASE]
+    )
+    checkout_idx = called_cmds.index(["git", "checkout", "-"])
+    assert checkout_idx > push_idx
+
+
+@patch("reana.reana_dev.git.display_message")
+@patch("reana.reana_dev.git.branch_exists", return_value=False)
+@patch("reana.reana_dev.git.select_components", return_value=[COMPONENT])
+@patch("reana.reana_dev.git.run_command")
+def test_shell_metacharacters_in_branch_name(
+    mock_run, mock_select, mock_exists, mock_display
+):
+    """Branch names with shell metacharacters are passed as list elements, not interpolated."""
+    unsafe_base = "maint;echo"
+    mock_run.side_effect = _ls_remote_returns(f"abc123\trefs/heads/{unsafe_base}")
+
+    result = _invoke(base=unsafe_base, create_branch=True)
+
+    assert result.exit_code == 0
+    called_cmds = [c.args[0] for c in mock_run.call_args_list]
+    # Defensive guard: no shell-string command should ever interpolate the
+    # branch name. Today every command in this code path is list-form, so
+    # this loop is a no-op. It exists to catch a future regression where
+    # someone reintroduces an f-string into a shell-form run_command call.
+    for cmd in called_cmds:
+        if isinstance(cmd, str):
+            assert (
+                unsafe_base not in cmd
+            ), f"Branch name interpolated into shell string: {cmd!r}"
+    assert [
+        "git",
+        "checkout",
+        "-b",
+        unsafe_base,
+        f"upstream/{unsafe_base}",
+    ] in called_cmds
+    assert ["git", "push", "-u", "origin", unsafe_base] in called_cmds
+
+
+@patch("reana.reana_dev.git.display_message")
+@patch("reana.reana_dev.git.branch_exists", return_value=True)
+@patch("reana.reana_dev.git.select_components", return_value=[COMPONENT])
+@patch("reana.reana_dev.git.run_command")
+def test_existing_branch_runs_merge_push_flow(
+    mock_run, mock_select, mock_exists, mock_display
+):
+    """When the local branch exists, the upgrade runs fetch / checkout / ff-merge / push / restore in order."""
+    result = _invoke()
+
+    assert result.exit_code == 0
+    assert [c.args[0] for c in mock_run.call_args_list] == [
+        ["git", "fetch", "upstream"],
+        ["git", "checkout", BASE],
+        ["git", "merge", "--ff-only", f"upstream/{BASE}"],
+        ["git", "push", "origin", BASE],
+        ["git", "checkout", "-"],
+    ]


### PR DESCRIPTION
This commit adds a --create-branch option to the git-upgrade command. When used, it creates the branch locally from the upstream branch and pushes it to the origin, if the branch exists in upstream. This option is especially useful when upgrading maintenance branches that don't exist locally or in your fork.

Replaces https://github.com/reanahub/reana/pull/884
Co-authored-by: Alputer <alp.tuna.453@gmail.com>