### PR TITLE
feat(reana-dev): auto-create multi-arch release-docker builder

### DIFF
--- a/reana/reana_dev/release.py
+++ b/reana/reana_dev/release.py
@@ -25,6 +25,7 @@ from reana.reana_dev.git import (
 )
 from reana.reana_dev.utils import (
     display_message,
+    ensure_multiarch_builder,
     fetch_latest_pypi_version,
     get_current_component_version_from_source_files,
     get_docker_tag,
@@ -152,6 +153,8 @@ def release_docker(
     if not tags_only:
         # check whether docker buildx is available
         run_command("docker buildx version", display=False, return_output=True)
+        # ensure a multi-platform-capable builder is available
+        multiarch_builder = ensure_multiarch_builder()
 
     cannot_release_on_dockerhub = []
     for component_ in components:
@@ -167,6 +170,7 @@ def release_docker(
 
         # Build and push image using buildx (like GitHub Actions)
         cmd = "docker buildx build"
+        cmd += f" --builder {multiarch_builder}"
         cmd += f" --platform {','.join(platform)}"
         cmd += " --provenance=false"
         cmd += " --sbom=false"

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -1122,3 +1122,61 @@ $ colima start \\
     --vz-rosetta
 
 This script does not do this automatically. Exiting.""")
+
+
+def ensure_multiarch_builder() -> str:
+    """Ensure a docker-container driver buildx builder exists for multi-platform builds.
+
+    Multi-platform manifest-list builds (``--platform linux/amd64,linux/arm64``)
+    require buildx's ``docker-container`` driver. The default builder on Docker
+    Desktop and native Docker installs uses the ``docker`` driver, which cannot
+    build multi-platform manifest lists in a single command. This helper checks
+    for a ``docker-container`` builder named ``reana-multiarch``, creates it if
+    missing, and returns its name so callers can pass ``--builder <name>`` to
+    ``docker buildx build``. If a builder with that name exists but uses a
+    different driver, this exits with an error rather than silently failing the
+    later build.
+
+    :return: name of a usable docker-container driver builder
+    :rtype: str
+    """
+    builder_name = "reana-multiarch"
+    required_driver = "docker-container"
+    try:
+        output = run_command(
+            f"docker buildx inspect {builder_name}",
+            display=False,
+            return_output=True,
+            exit_on_error=False,
+        )
+    except subprocess.CalledProcessError:
+        click.secho(
+            f"Creating docker-container buildx builder '{builder_name}' "
+            "for multi-platform builds...",
+            fg="yellow",
+        )
+        run_command(
+            f"docker buildx create --name {builder_name} "
+            f"--driver {required_driver} --bootstrap"
+        )
+        return builder_name
+
+    match = re.search(r"^Driver:\s*(\S+)", output, re.MULTILINE)
+    if not match:
+        click.secho(
+            f"Could not determine driver of buildx builder '{builder_name}'. "
+            f"Inspect manually with 'docker buildx inspect {builder_name}'.",
+            fg="red",
+        )
+        sys.exit(1)
+    current_driver = match.group(1)
+    if current_driver != required_driver:
+        click.secho(
+            f"Buildx builder '{builder_name}' exists but uses driver "
+            f"'{current_driver}' instead of required '{required_driver}'. "
+            f"Remove it with 'docker buildx rm {builder_name}' and re-run "
+            "to let this helper recreate it.",
+            fg="red",
+        )
+        sys.exit(1)
+    return builder_name


### PR DESCRIPTION
Multi-platform manifest-list builds (--platform linux/amd64,linux/arm64) require buildx's docker-container driver. The default builder on Docker Desktop and native Docker installations use the docker driver, which cannot build multi-platform manifest lists. Add
ensure_multiarch_builder() that creates a reana-multiarch builder on first invocation and passes its name to docker buildx build, making release-docker portable across all common developer setups.