### PR TITLE
fix(reana-dev): avoid multi-manifest indices in kind load

### DIFF
--- a/reana/reana_dev/cli.py
+++ b/reana/reana_dev/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2022 CERN.
+# Copyright (C) 2020, 2021, 2022, 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -170,7 +170,7 @@ def reana_dev():  # noqa: D301
         $ cd ~/mysrc/reana-server
         $ reana-dev git-clean -c .
         $ # Build the docker image
-        $ reana-dev docker-build --platform linux/amd64 --platform linux/arm64 -c .
+        $ reana-dev docker-build -c .
         $ # Tag and release the image
         $ reana-dev git-tag -c .
         $ reana-dev release-docker --platform linux/amd64 --platform linux/arm64 -c .

--- a/reana/reana_dev/docker.py
+++ b/reana/reana_dev/docker.py
@@ -89,7 +89,8 @@ def _run_command_prefix_output(cmd, component):
 @click.option(
     "--platform",
     multiple=True,
-    help="Platforms for multi-arch images [default=current architecture]",
+    help="Platform for the build [default=current architecture]. "
+    "For multi-arch builds, use 'release-docker' instead.",
 )
 @docker_commands.command(name="docker-build")
 @click.pass_context
@@ -134,7 +135,7 @@ def docker_build(
         tags. Useful when using `--tag auto` since every REANA component
         will have a different tag.
     :param parallel: Number of docker images to build in parallel.
-    :param platform: Platforms for multi-arch images. [default=current architecture]
+    :param platform: Platform for the build. [default=current architecture]
     :type component: str
     :type exclude_components: str
     :type user: str
@@ -152,7 +153,7 @@ def docker_build(
 
     if len(platform) > 1:
         click.secho(
-            "ERROR: The 'docker-build' command now supports single-platform builds\n"
+            "ERROR: The 'docker-build' command supports single-platform builds\n"
             "only. If you would like to build and push a multi-platform image, please\n"
             "use the 'release-docker' command instead. For example:\n\n"
             "$ reana-dev release-docker -c . --platform linux/amd64 --platform linux/arm64",
@@ -174,7 +175,13 @@ def docker_build(
             component_version_tag = "docker.io/{0}/{1}:{2}".format(
                 user, component, component_tag
             )
-            cmd = "docker build"
+            # Disable attestations so that locally built images stay a
+            # single, self-contained manifest. This is not strictly
+            # required for `reana-dev kind-load-docker-image` (which
+            # platform-filters at save time), but keeps the local image
+            # record clean and avoids carrying SLSA/SBOM blobs that have
+            # no destination outside of a registry push.
+            cmd = "docker buildx build --provenance=false --sbom=false --load"
             for arg in build_arg:
                 cmd += " --build-arg {0}".format(arg)
             if no_cache:
@@ -190,6 +197,10 @@ def docker_build(
         else:
             msg = "Ignoring this component that does not contain" " a Dockerfile."
             display_message(msg, component)
+
+    if commands:
+        # Fail fast with a clear message if buildx is absent
+        run_command("docker buildx version", display=False, return_output=True)
 
     execute_parallel(
         commands,

--- a/reana/reana_dev/kind.py
+++ b/reana/reana_dev/kind.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2023, 2025 CERN.
+# Copyright (C) 2020, 2021, 2023, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """`reana-dev`'s kind commands."""
+
+import os
+import tempfile
 
 import click
 
@@ -24,7 +27,56 @@ def kind_commands():
     """Kind commands group."""
 
 
+def _kind_load_image(image, nodes, component):
+    """Load a Docker image into the local kind cluster.
+
+    Goes via a platform-pinned ``docker image save`` plus
+    ``kind load image-archive``, rather than ``kind load docker-image``.
+    The latter shells out to ``docker save`` without a platform filter,
+    which on daemons that use the containerd image store (default on
+    Docker Desktop and progressively rolling out on Docker CE) exports
+    the full multi-arch index even when only one platform was pulled.
+    The subsequent ``ctr import --all-platforms --digests`` inside the
+    kind node then aborts on the first sibling-manifest digest whose
+    content is not in the archive. Saving with ``--platform`` produces
+    a single-manifest tarball that imports cleanly.
+
+    The platform is read from the local image record (not from the
+    daemon platform), because single-platform upstream images may have
+    been pulled under emulation — e.g. an amd64-only image on an arm64
+    daemon. ``docker image save --platform <daemon>`` would then fail
+    with ``no suitable export target found``.
+
+    This is a workaround for a Kind issue tracked upstream at
+    https://github.com/kubernetes-sigs/kind/issues/3795.
+    """
+    platform = run_command(
+        "docker image inspect --format '{{.Os}}/{{.Architecture}}' " + image,
+        display=False,
+        return_output=True,
+    )
+    fd, archive = tempfile.mkstemp(suffix=".tar", prefix="reana-kind-load-")
+    os.close(fd)
+    try:
+        run_command(
+            "docker image save --platform {0} -o {1} {2}".format(
+                platform, archive, image
+            ),
+            component,
+        )
+        cmd = "kind load image-archive {0}".format(archive)
+        if nodes:
+            cmd = "{0} --nodes {1}".format(cmd, ",".join(nodes))
+        run_command(cmd, component)
+    finally:
+        try:
+            os.unlink(archive)
+        except FileNotFoundError:
+            pass
+
+
 @click.option("--user", "-u", default="reanahub", help="DockerHub user name [reanahub]")
+@click.option("--tag", "-t", default="latest", help="Image tag [latest]")
 @click.option(
     "--component",
     "-c",
@@ -44,11 +96,14 @@ def kind_commands():
     help="Which components to exclude from build? [c1,c2,c3]",
 )
 @kind_commands.command(name="kind-load-docker-image")
-def kind_load_docker_image(user, component, node, exclude_components):  # noqa: D301
+def kind_load_docker_image(
+    user, tag, component, node, exclude_components
+):  # noqa: D301
     """Load Docker images to the cluster.
 
     \b
     :param user: DockerHub organisation or user name. [default=reanahub]
+    :param tag: Docker tag to use. [default=latest]
     :param components: The option ``component`` can be repeated. The value may
                        consist of:
                          * (1) standard component name such as
@@ -66,6 +121,7 @@ def kind_load_docker_image(user, component, node, exclude_components):  # noqa: 
                                all REANA repositories.
     :param exclude_components: List of components to exclude from the build.
     :type user: str
+    :type tag: str
     :type component: str
     :type exclude_components: str
     """
@@ -74,15 +130,14 @@ def kind_load_docker_image(user, component, node, exclude_components):  # noqa: 
     for component in select_components(component, exclude_components):
         if component in DOCKER_PREFETCH_IMAGES:
             for image in DOCKER_PREFETCH_IMAGES[component]:
-                cmd = "kind load docker-image {0}".format(image)
-                if node:
-                    cmd = f"{cmd} --nodes {','.join(node)}"
-                run_command(cmd, component)
+                _kind_load_image(image, node, component)
         elif is_component_dockerised(component):
-            cmd = "kind load docker-image docker.io/{0}/{1}".format(user, component)
-            if node:
-                cmd = f"{cmd} --nodes {','.join(node)}"
-            run_command(cmd, component)
+            # Always pass an explicit tag: with Docker's containerd
+            # image store, a bare repo name can match multiple tagged
+            # images (e.g. a fresh local build plus older `:0.9.x`
+            # pulls), and `docker image save` may pick the wrong one.
+            image = "docker.io/{0}/{1}:{2}".format(user, component, tag)
+            _kind_load_image(image, node, component)
         else:
             msg = "Ignoring this component that does not contain" " a Dockerfile."
             display_message(msg, component)


### PR DESCRIPTION
The `kind load docker-image` command fails on daemons that use the containerd image store (default on Docker Desktop, progressively rolling out on Docker CE). It shells out to `docker save` without a platform filter and feeds the result to `ctr import --all-platforms --digests` inside the node; the saved archive references every sibling manifest in the multi-arch index — both other platforms and SLSA/SBOM attestations — but only carries the blobs for the locally fetched platform, so the import aborts on the first missing referenced digest.

For `kind-load-docker-image`, switch to a platform-pinned `docker image save -o <tar>` plus `kind load image-archive <tar>`. The filtered archive contains a single manifest, so the import is clean regardless of which image store the daemon uses. The platform is read from the local image record via `docker image inspect --format '{{.Os}}/{{.Architecture}}'`, so single-platform upstream images pulled under emulation (e.g. amd64-only images on an arm64 daemon) still match what Docker actually stored, rather than tripping on a non-existent daemon-native variant. Always pass an explicit image tag, since on the containerd image store a bare repo name can match multiple tagged images and `docker image save` may then resolve to the wrong one. Expose `-t/--tag` (default `latest`) to make the tag selectable, matching the sibling `docker-pull` and `docker-build` commands.

For `docker-build`, switch to `docker buildx build --provenance=false --sbom=false --load` so locally built images are a single self-contained manifest, and check buildx availability only when at least one dockerised component is queued for build.