### PR TITLE
fix(reana-dev): activate environment using dot-source command

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,7 @@ organisation on GitHub, in alphabetical order:
 - [Adelina Lintuluoto](https://orcid.org/0000-0002-0726-1452)
 - [Agisilaos Kounelis](https://orcid.org/0000-0001-9312-3189)
 - [Alastair Lyall](https://orcid.org/0009-0000-4955-8935)
+- [Alexander Sohn](https://orcid.org/0009-0000-3673-4637)
 - [Alizee Pace](https://www.linkedin.com/in/aliz%C3%A9e-pace-516b4314b/)
 - [Alp Tuna](https://orcid.org/0009-0001-1915-3993)
 - [Ana Trisovic](https://orcid.org/0000-0003-1991-0533)

--- a/reana/reana_dev/python.py
+++ b/reana/reana_dev/python.py
@@ -134,7 +134,7 @@ def python_unit_tests(
             )
             display_message(msg, component)
         elif is_component_python_package(component):
-            cmd_activate_venv = f"source  ~/.virtualenvs/_{component}/bin/activate"
+            cmd_activate_venv = f".  ~/.virtualenvs/_{component}/bin/activate"
             if does_component_need_db(component):
                 run_command(
                     f"docker stop postgres__{component}\n"


### PR DESCRIPTION
Running the python unit tests with the `reana-dev` wrapper failed on ubuntu, because the default shell does not support the `source` feature. This pr replaces source with the more general `. /path/to/source` syntax, making it compatible with ubuntu. 

Fixes #962 