### PR TITLE
perf(reana-dev): speed up git-status on macOS

### DIFF
--- a/reana/reana_dev/client.py
+++ b/reana/reana_dev/client.py
@@ -89,10 +89,17 @@ def client_setup_environment(
                 env_var_value=server_hostname or "https://localhost:30443",
             )
         )
-        get_access_token_cmd = f"kubectl get secret -n {namespace} -o json {instance_name}-admin-access-token"
-        secret_json = json.loads(
-            subprocess.check_output(get_access_token_cmd, shell=True).decode()
-        )
+        get_access_token_cmd = [
+            "kubectl",
+            "get",
+            "secret",
+            "-n",
+            namespace,
+            "-o",
+            "json",
+            f"{instance_name}-admin-access-token",
+        ]
+        secret_json = json.loads(subprocess.check_output(get_access_token_cmd).decode())
         admin_access_token_b64 = secret_json["data"]["ADMIN_ACCESS_TOKEN"]
         admin_access_token = base64.b64decode(admin_access_token_b64).decode()
         export_lines.append(

--- a/reana/reana_dev/docker.py
+++ b/reana/reana_dev/docker.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2023, 2026 CERN.
+# Copyright (C) 2020, 2021, 2022, 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -18,6 +18,7 @@ from reana.reana_dev.utils import (
     get_docker_tag,
     is_component_dockerised,
     run_command,
+    run_command_prefix_output,
     execute_parallel,
     select_components,
 )
@@ -26,17 +27,6 @@ from reana.reana_dev.utils import (
 @click.group()
 def docker_commands():
     """Docker commands group."""
-
-
-def _run_command_prefix_output(cmd, component):
-    """Run given command, showing the component's name before each output line.
-
-    :param cmd: Command to be executed.
-    :param component: Name of the REANA component.
-    """
-    output = run_command(cmd, component, return_output=True)
-    for line in output.splitlines():
-        click.echo(click.style(f"[{component}] ", bold=True) + line)
 
 
 @click.option("--user", "-u", default="reanahub", help="DockerHub user name [reanahub]")
@@ -166,7 +156,7 @@ def docker_build(
     # show the component's name before each output line of `docker build` if there
     # are multiple parallel builds at the same time, as in this case build logs
     # from different components are mixed together
-    _run_command = run_command if parallel == 1 else _run_command_prefix_output
+    _run_command = run_command if parallel == 1 else run_command_prefix_output
 
     commands = []
     for component in components:

--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional
 
 import click
@@ -1134,8 +1135,15 @@ def git_merge(branch, base, push):  # noqa: D301
     default="",
     help="Which components to exclude? [c1,c2,c3]",
 )
+@click.option(
+    "--parallel",
+    "-p",
+    default=8,
+    type=click.IntRange(min=1),
+    help="Number of components to fetch in parallel. [default=8]",
+)
 @git_commands.command(name="git-fetch")
-def git_fetch(component, exclude_components):  # noqa: D301
+def git_fetch(component, exclude_components, parallel):  # noqa: D301
     """Fetch REANA upstream source code repositories without upgrade.
 
     \b
@@ -1155,14 +1163,93 @@ def git_fetch(component, exclude_components):  # noqa: D301
                          * (7) special value 'ALL' that will expand to include
                                all REANA repositories.
     :param exclude_components: List of components to exclude.
+    :param parallel: How many components to fetch in parallel. [default=8]
     :type component: str
     :type exclude_components: str
+    :type parallel: int
     """
     if exclude_components:
         exclude_components = exclude_components.split(",")
-    for component in select_components(component, exclude_components):
-        cmd = "git fetch upstream"
-        run_command(cmd, component)
+    components = select_components(component, exclude_components)
+    if parallel == 1 or len(components) <= 1:
+        for component in components:
+            run_command("git fetch upstream", component)
+        return
+    # Pre-warm: fetch the first component serially before spinning up the
+    # parallel pool. If the user's ssh config enables `ControlMaster`,
+    # this lets the first connection establish the shared master socket
+    # so the parallel workers reuse it instead of racing to create it
+    # (and printing "ControlSocket already exists, disabling
+    # multiplexing" warnings as they lose the race). For users without
+    # `ControlMaster`, the pre-warm is harmless — the first component
+    # was going to be fetched anyway.
+    failed = []
+    prewarm = components[0]
+    try:
+        run_command("git fetch upstream", prewarm, exit_on_error=False)
+    except subprocess.CalledProcessError:
+        # `run_command` already logged the failure with a component prefix.
+        failed.append(prewarm)
+    # Concurrent fetches for the remaining components: each worker
+    # captures both stdout and stderr (`git fetch` writes progress and
+    # SSH ControlMaster warnings to stderr) and returns them to the
+    # parent, which prints every component's block atomically in
+    # completion order. Failures are collected and surfaced via a
+    # non-zero exit at the end so the parallel path keeps the same
+    # exit-status semantics as the serial path.
+    with ThreadPoolExecutor(max_workers=parallel) as executor:
+        future_to_component = {
+            executor.submit(_fetch_upstream_capture, component): component
+            for component in components[1:]
+        }
+        for future in as_completed(future_to_component):
+            component = future_to_component[future]
+            output, returncode = future.result()
+            # Match the serial `run_command` display: a timestamped header
+            # per component, followed by the captured output verbatim.
+            # With `as_completed` each component appears as a contiguous
+            # block, so the captured lines do not need a per-line prefix
+            # to stay attributable.
+            now = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+            click.secho(f"[{now}] ", bold=True, nl=False, fg="green")
+            click.secho(f"{component}: ", bold=True, nl=False, fg="yellow")
+            click.secho("git fetch upstream", bold=True)
+            for line in output.splitlines():
+                click.echo(line)
+            if returncode != 0:
+                failed.append(component)
+                click.secho(f"[{now}] ", bold=True, nl=False, fg="green")
+                click.secho(f"{component}: ", bold=True, nl=False, fg="yellow")
+                click.secho(
+                    f"git fetch failed (exit {returncode})", bold=True, fg="red"
+                )
+    if failed:
+        display_message(
+            f"git fetch failed for {len(failed)} component(s): " f"{', '.join(failed)}",
+            component="reana",
+        )
+        sys.exit(1)
+
+
+def _fetch_upstream_capture(component):
+    """Run ``git fetch upstream`` for one component, capturing all output.
+
+    Returns ``(combined_output, returncode)`` rather than raising, so the
+    parent can prefix every line per component, collect failures across
+    all components and exit non-zero at the end. ``stderr`` is merged
+    into ``stdout`` because ``git fetch`` writes its progress lines, its
+    error messages and any SSH ``ControlMaster`` warnings to stderr —
+    leaving stderr uncaptured would interleave that traffic between
+    concurrent workers and lose the per-component attribution.
+    """
+    result = subprocess.run(
+        ["git", "fetch", "upstream"],
+        cwd=get_srcdir(component),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return result.stdout, result.returncode
 
 
 @click.option(

--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -71,11 +71,29 @@ def get_all_branches(srcdir):
     :return: checkout out branch in the component source code directory
     :rtype: str
     """
-    os.chdir(srcdir)
     return (
-        subprocess.check_output("git branch -a 2>/dev/null", shell=True)
+        subprocess.check_output(
+            ["git", "branch", "-a"],
+            cwd=srcdir,
+            stderr=subprocess.DEVNULL,
+        )
         .decode()
         .split()
+    )
+
+
+def remote_ref_exists(srcdir, branch):
+    """Return whether ``refs/remotes/<branch>`` exists in the given repo.
+
+    Cheaper than scanning ``git branch -a`` output: a single ``git show-ref``
+    call with no shell pipeline.
+    """
+    return (
+        subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/remotes/{branch}"],
+            cwd=srcdir,
+        ).returncode
+        == 0
     )
 
 
@@ -93,16 +111,20 @@ def branch_exists(component, branch):
 def get_current_branch(srcdir):
     """Return current Git branch name checked out in the given directory.
 
+    Returns ``"HEAD"`` when the working tree is in a detached-HEAD state;
+    callers in the ``git-status`` hot path detect that and skip the
+    branch-comparison logic.
+
     :param srcdir: source code directory
     :type srcdir: str
 
     :return: checkout out branch in the component source code directory
     :rtype: str
     """
-    os.chdir(srcdir)
     return (
         subprocess.check_output(
-            'git branch 2>/dev/null | grep "^*" | colrm 1 2', shell=True
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=srcdir,
         )
         .decode()
         .rstrip("\r\n")
@@ -118,9 +140,11 @@ def get_current_commit(srcdir):
     :return: commit information composed of brief SHA1 and subject
     :rtype: str
     """
-    os.chdir(srcdir)
     return (
-        subprocess.check_output('git log --pretty=format:"%h %s" -n 1', shell=True)
+        subprocess.check_output(
+            ["git", "log", "--pretty=format:%h %s", "-n", "1"],
+            cwd=srcdir,
+        )
         .decode()
         .rstrip("\r\n")
     )
@@ -229,25 +253,29 @@ def git_create_release_commit(
     return True
 
 
-def compare_branches(branch_to_compare, current_branch):
-    """Compare two branches with ``git rev-list``."""
-    cmd = "git branch -a | grep -c remotes/{}".format(branch_to_compare)
-    try:
-        check = subprocess.check_output(cmd, shell=True)
-    except subprocess.CalledProcessError:
-        check = 0
-    if check == 0:
+def compare_branches(srcdir, branch_to_compare, current_branch):
+    """Compare two branches with ``git rev-list``.
+
+    Runs entirely in ``srcdir`` via ``cwd=`` — no global ``os.chdir`` side
+    effect and no shell pipeline, which keeps per-component overhead low on
+    platforms where ``fork``/``exec`` is slow (notably macOS).
+    """
+    if not remote_ref_exists(srcdir, branch_to_compare):
         click.secho(
             "ERROR: Branch {} does not exist.".format(branch_to_compare), fg="red"
         )
         return 0, 0
-
-    cmd = "git rev-list --left-right --count {0}...{1}".format(
-        branch_to_compare, current_branch
-    )
-    behind, ahead = [
-        int(x) for x in run_command(cmd, display=False, return_output=True).split()
-    ]
+    output = subprocess.check_output(
+        [
+            "git",
+            "rev-list",
+            "--left-right",
+            "--count",
+            "{0}...{1}".format(branch_to_compare, current_branch),
+        ],
+        cwd=srcdir,
+    ).decode()
+    behind, ahead = [int(x) for x in output.split()]
     return behind, ahead
 
 
@@ -257,8 +285,9 @@ def is_component_behind_branch(
     current_branch=None,
 ):
     """Report to stdout the differences between two branches."""
-    current_branch = current_branch or get_current_branch(get_srcdir(component))
-    behind, _ = compare_branches(branch_to_compare, current_branch)
+    srcdir = get_srcdir(component)
+    current_branch = current_branch or get_current_branch(srcdir)
+    behind, _ = compare_branches(srcdir, branch_to_compare, current_branch)
     return bool(behind)
 
 
@@ -269,29 +298,37 @@ def print_branch_difference_report(
     base=GIT_DEFAULT_BASE_BRANCH,
     commit=None,
     short=False,
+    srcdir=None,
 ):
-    """Report to stdout the differences between two branches."""
+    """Report to stdout the differences between two branches.
+
+    When ``branch_to_compare`` is ``None`` (e.g. detached HEAD), the
+    ahead/behind comparison is skipped entirely, but ``short=True`` still
+    prints ``git status --short`` so the report stays useful.
+    """
     # detect how far it is ahead/behind from pr/origin/upstream
-    current_branch = current_branch or get_current_branch(get_srcdir(component))
-    commit = commit or get_current_commit(get_srcdir(component))
+    srcdir = srcdir or get_srcdir(component)
+    current_branch = current_branch or get_current_branch(srcdir)
+    commit = commit or get_current_commit(srcdir)
     report = ""
-    behind, ahead = compare_branches(branch_to_compare, current_branch)
-    if ahead or behind:
-        report += "("
-        if ahead:
-            report += "{0} AHEAD ".format(ahead)
-        if behind:
-            report += "{0} BEHIND ".format(behind)
-        report += branch_to_compare + ")"
-    # detect rebase needs for local branches and PRs
-    if branch_to_compare != "upstream/{}".format(base):
-        branch_to_compare = "upstream/{}".format(base)
-        behind, ahead = compare_branches(branch_to_compare, current_branch)
-        if behind:
-            report += "(STEMS FROM "
+    if branch_to_compare is not None:
+        behind, ahead = compare_branches(srcdir, branch_to_compare, current_branch)
+        if ahead or behind:
+            report += "("
+            if ahead:
+                report += "{0} AHEAD ".format(ahead)
             if behind:
                 report += "{0} BEHIND ".format(behind)
             report += branch_to_compare + ")"
+        # detect rebase needs for local branches and PRs
+        if branch_to_compare != "upstream/{}".format(base):
+            branch_to_compare = "upstream/{}".format(base)
+            behind, ahead = compare_branches(srcdir, branch_to_compare, current_branch)
+            if behind:
+                report += "(STEMS FROM "
+                if behind:
+                    report += "{0} BEHIND ".format(behind)
+                report += branch_to_compare + ")"
 
     click.secho("{0}".format(component), nl=False, bold=True)
     click.secho(" @ ", nl=False, dim=True)
@@ -560,20 +597,29 @@ def git_status(component, exclude_components, short, base):  # noqa: D301
         exclude_components = exclude_components.split(",")
     components = select_components(component, exclude_components)
     for component in components:
-        current_branch = get_current_branch(get_srcdir(component))
-        # detect all local and remote branches
-        all_branches = get_all_branches(get_srcdir(component))
+        srcdir = get_srcdir(component)
+        current_branch = get_current_branch(srcdir)
+        commit = get_current_commit(srcdir)
         # detect branch to compare against
-        if current_branch == base:  # base branch
+        if current_branch == "HEAD":  # detached HEAD
+            branch_to_compare = None
+            current_branch = "(detached HEAD)"
+        elif current_branch == base:  # base branch
             branch_to_compare = "upstream/" + base
         elif current_branch.startswith("pr-"):  # other people's PR
             branch_to_compare = "upstream/" + current_branch.replace("pr-", "pr/")
         else:
             branch_to_compare = "origin/" + current_branch  # my PR
-            if "remotes/" + branch_to_compare not in all_branches:
+            if not remote_ref_exists(srcdir, branch_to_compare):
                 branch_to_compare = "origin/" + base  # local unpushed branch
         print_branch_difference_report(
-            component, branch_to_compare, base=base, short=short
+            component,
+            branch_to_compare,
+            current_branch=current_branch,
+            commit=commit,
+            base=base,
+            short=short,
+            srcdir=srcdir,
         )
 
 

--- a/reana/reana_dev/git.py
+++ b/reana/reana_dev/git.py
@@ -98,14 +98,25 @@ def remote_ref_exists(srcdir, branch):
 
 
 def branch_exists(component, branch):
-    """Check whether a branch exists on a given component.
+    """Check whether a local branch exists on a given component.
+
+    Uses ``git show-ref --verify --quiet refs/heads/<branch>`` rather than
+    scanning ``git branch -a`` output — one cheap process, no shell, and no
+    false positives on remote-tracking ref aliases (e.g. ``origin/master``
+    appearing tokenised in ``remotes/origin/HEAD -> origin/master``).
 
     :param component: Component in which check whether the branch exists.
-    :param branch: Name of the branch.
+    :param branch: Name of the local branch.
     :return: Whether the branch exists in components git repo.
     :rtype: bool
     """
-    return branch in get_all_branches(get_srcdir(component))
+    return (
+        subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+            cwd=get_srcdir(component),
+        ).returncode
+        == 0
+    )
 
 
 def get_current_branch(srcdir):

--- a/reana/reana_dev/release.py
+++ b/reana/reana_dev/release.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2022, 2023, 2026 CERN.
+# Copyright (C) 2020, 2021, 2022, 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -451,8 +451,7 @@ def release_docker_copy(
         if not overwrite_existing and not dry_run:
             try:
                 subprocess.check_output(
-                    f"docker buildx imagetools inspect {dst_image}",
-                    shell=True,
+                    ["docker", "buildx", "imagetools", "inspect", dst_image],
                     stderr=subprocess.DEVNULL,
                 )
                 display_message(

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -148,7 +148,7 @@ def find_reana_srcdir():
     # second, try from the parent of git toplevel:
     try:
         toplevel = (
-            subprocess.check_output("git rev-parse --show-toplevel", shell=True)
+            subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
             .decode()
             .rstrip("\r\n")
         )

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -184,16 +184,18 @@ def get_srcdir(component=""):
 def get_current_branch(srcdir):
     """Return current Git branch name checked out in the given directory.
 
+    Returns ``"HEAD"`` when the working tree is in a detached-HEAD state.
+
     :param srcdir: source code directory
     :type srcdir: str
 
     :return: checkout out branch in the component source code directory
     :rtype: str
     """
-    os.chdir(srcdir)
     return (
         subprocess.check_output(
-            'git branch 2>/dev/null | grep "^*" | colrm 1 2', shell=True
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=srcdir,
         )
         .decode()
         .rstrip("\r\n")

--- a/reana/reana_dev/utils.py
+++ b/reana/reana_dev/utils.py
@@ -394,6 +394,20 @@ def run_command(
             raise
 
 
+def run_command_prefix_output(cmd, component):
+    """Run given command, showing the component's name before each output line.
+
+    Useful when commands run concurrently (e.g. via :func:`execute_parallel`)
+    and their output would otherwise be interleaved.
+
+    :param cmd: Command to be executed.
+    :param component: Name of the REANA component.
+    """
+    output = run_command(cmd, component, return_output=True)
+    for line in output.splitlines():
+        click.echo(click.style(f"[{component}] ", bold=True) + line)
+
+
 @dataclass
 class ExecutionProgress:
     """Progress of the parallel execution of multiple tasks."""


### PR DESCRIPTION
Each per-component step in `reana-dev git-status` previously shelled out
via `subprocess.check_output(..., shell=True)` with pipelines like `git
branch | grep "^*" | colrm 1 2` and `git branch -a | grep -c
remotes/<branch>`. Each `shell=True` call forks `/bin/sh`, which in turn
forks `git` and any pipeline helpers. On macOS where `fork`/`exec`
carries dyld closure resolution, library validation and AMFI checks,
this overhead dominated the runtime.

Rework the hot path to call `git` directly with list-form arguments and
`cwd=srcdir`:

  - New `remote_ref_exists(srcdir, branch)` helper using `git show-ref
    --verify --quiet refs/remotes/<branch>`, used in both
    `compare_branches` and `git_status` instead of the `git branch -a |
    grep` pipeline and the `"remotes/..." in get_all_branches(...)`
    membership test.
  - `get_current_branch` (in `git.py` and `utils.py`),
    `get_current_commit` and `get_all_branches` rewritten to use list
    arguments, `cwd=srcdir` and no shell pipeline.
  - `compare_branches` now takes `srcdir` explicitly, making the
    no-`chdir` contract obvious and avoiding a hidden
    `get_srcdir(component)` lookup inside.
  - `print_branch_difference_report` takes an optional `srcdir`, accepts
    a pre-computed `current_branch`/`commit` from the caller
    (`git_status` already had them) and tolerates
    `branch_to_compare=None` for detached-HEAD checkouts, in which case
    the ahead/behind comparison is skipped but `--short` still prints
    `git status --short`.
  - `is_component_behind_branch` computes `srcdir` once and threads it
    to `compare_branches`.
  - `git_status` now computes `srcdir` once per component, detects
    detached HEAD (`git rev-parse --abbrev-ref HEAD` returns `HEAD`) and
    prints `(detached HEAD)` instead of erroring on a non-existent
    `origin/HEAD` lookup.

For the frequently used `reana-dev git-status -c CLUSTER -c CLIENT -c
reana` command, which walks 19 REANA source repositories, wall-clock
time on macOS drops from ~2.4s to ~1.3s (~1.9x), with user CPU time
falling from ~1.0s to ~0.4s and system CPU time from ~1.0s to ~0.3s.

Output is byte-identical for branches that exist on
`master`/`origin`/`upstream`. Detached-HEAD output is intentionally not
byte-identical: today's pipeline emits a literal `(HEAD detached at
<sha>)` label and then trips the downstream `origin/...` lookup with an
`ERROR: Branch ... does not exist` line; the rewrite detects the
detached state up front, prints `(detached HEAD)` and skips the
ahead/behind comparison.