### PR TITLE
feat(helm): pass vetted image policy to job controllers

### DIFF
--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -217,7 +217,10 @@ spec:
             value: {{ .Values.components.reana_workflow_engine_yadage.environment | toJson | quote }}
           # Environment variables for job controller
           - name: REANA_JOB_CONTROLLER_ENV_VARS
-            value: {{ .Values.components.reana_job_controller.environment | toJson | quote }}
+            value: {{ (merge
+              (dict "REANA_VETTED_CONTAINER_IMAGES" (.Values.vetted_container_images | toJson))
+              (default (dict) .Values.components.reana_job_controller.environment)
+              ) | toJson | quote }}
           - name: REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS
             value: {{ .Values.interactive_sessions.environments | toJson | quote }}
           - name: TRAEFIK_ENABLED

--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -38,7 +38,8 @@ compute_backends:
   - kubernetes
 
 # When enabled, users can only run workflows that use container
-# images specified in the `allowlist`
+# images specified in the `allowlist`. Snakemake's default image must
+# also be listed when workflows omit an explicit container directive.
 vetted_container_images:
   enabled: false # Toggle container image vetting
   allowlist: [] # List of authorized container images

--- a/tests/test_helm.py
+++ b/tests/test_helm.py
@@ -8,6 +8,7 @@
 
 """Tests for reana-dev helm-* commands."""
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -106,4 +107,81 @@ def test_nginx_config_quoted_origins(tmp_path):
     assert (
         r'add_header Permissions-Policy "geolocation=(self \"https://example.org\")" always;'
         in nginx_conf
+    )
+
+
+@pytest.mark.skipif(
+    not shutil.which("helm"),
+    reason="helm must be installed",
+)
+@pytest.mark.parametrize(
+    "job_controller_environment",
+    [
+        pytest.param({}, id="no-operator-override"),
+        pytest.param(
+            {
+                "REANA_VETTED_CONTAINER_IMAGES": (
+                    '{"enabled": false, "allowlist": ["stale.example/image"]}'
+                )
+            },
+            id="chart-policy-overrides-operator-environment",
+        ),
+    ],
+)
+def test_job_controller_receives_vetted_container_images(
+    tmp_path, job_controller_environment
+):
+    """Vetted-image settings must reach job-controller as nested JSON."""
+    values_file = tmp_path / "values.yaml"
+    vetted_images = {
+        "enabled": True,
+        "allowlist": ["docker.io/snakemake/snakemake:v9.22.0"],
+    }
+    values_file.write_text(
+        yaml.dump(
+            {
+                "components": {
+                    "reana_job_controller": {
+                        "environment": job_controller_environment,
+                    }
+                },
+                "secrets": {
+                    "cache": {"user": "test", "password": "test"},
+                    "database": {"user": "test", "password": "test"},
+                    "message_broker": {"user": "test", "password": "test"},
+                    "reana": {"REANA_SECRET_KEY": "test"},
+                },
+                "vetted_container_images": vetted_images,
+            }
+        )
+    )
+
+    if not any((HELM_CHART / "charts").glob("*.tgz")):
+        subprocess.run(
+            ["helm", "dependency", "update", str(HELM_CHART)],
+            capture_output=True,
+            check=True,
+        )
+
+    rendered = subprocess.run(
+        ["helm", "template", "reana", str(HELM_CHART), "-f", str(values_file)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    workflow_controller_env = None
+    for document in yaml.safe_load_all(rendered.stdout):
+        if not document or document.get("kind") != "Deployment":
+            continue
+        for container in document["spec"]["template"]["spec"]["containers"]:
+            for env_var in container.get("env", []):
+                if env_var["name"] == "REANA_JOB_CONTROLLER_ENV_VARS":
+                    workflow_controller_env = env_var["value"]
+                    break
+
+    assert workflow_controller_env is not None
+    job_controller_env = json.loads(workflow_controller_env)
+    assert (
+        json.loads(job_controller_env["REANA_VETTED_CONTAINER_IMAGES"]) == vetted_images
     )


### PR DESCRIPTION
Forward the chart-managed vetted-container-image policy through the
workflow controller. Document that the Snakemake default image must be
explicitly allowlisted.

Closes reanahub/reana-workflow-engine-snakemake#129

