### PR TITLE
feat(reana-dev): register reana-datastore-s3fs component

### DIFF
--- a/reana/config.py
+++ b/reana/config.py
@@ -47,6 +47,7 @@ REPO_LIST_ALL = [
     "reana-client",
     "reana-client-go",
     "reana-commons",
+    "reana-datastore-s3fs",
     "reana-db",
     "reana-env-aliphysics",
     "reana-env-jupyter",
@@ -108,6 +109,7 @@ REPO_LIST_CLUSTER = (
         "reana-auth-krb5",
         "reana-auth-rucio",
         "reana-auth-vomsproxy",
+        "reana-datastore-s3fs",
     ]
     + REPO_LIST_SHARED
     + REPO_LIST_CLUSTER_INFRASTRUCTURE

--- a/reana/reana_dev/wiki.py
+++ b/reana/reana_dev/wiki.py
@@ -81,6 +81,14 @@ def create_build_status_page():
                 "reana-auth-vomsproxy": {},
             },
         },
+        "datastores": {
+            "simple": True,
+            "title": "Datastores",
+            "description": "Selected data store components.",
+            "packages": {
+                "reana-datastore-s3fs": {},
+            },
+        },
         "examples": {
             "simple": True,
             "title": "Examples",


### PR DESCRIPTION
Add `reana-datastore-s3fs` component to the ALL and CLUSTER component selectors, and list it in the generated build status wiki page under Datastores.