### PR TITLE
fix(helm): add quota management secret default

### DIFF
--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -139,6 +139,7 @@ components:
       REANA_RATELIMIT_SLOW: "1/5 second"
       REANA_ACCESS_TOKEN_ISSUANCE_POLICY: "manual"
       REANA_TOKEN_MANAGEMENT_SECRET: ""
+      REANA_QUOTA_MANAGEMENT_SECRET: ""
     uwsgi:
       processes: 6
       threads: 4


### PR DESCRIPTION
Add the missing REANA_QUOTA_MANAGEMENT_SECRET default to the reana-server environment, matching the documented Helm chart value.

Leaving the value empty keeps the quota-management API endpoints disabled by default, consistently with token-management endpoint configuration.