### PR TITLE
feat(scripts): add local CERN CoreDNS helper

### DIFF
--- a/etc/cern-coredns-local.yaml
+++ b/etc/cern-coredns-local.yaml
@@ -1,0 +1,33 @@
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+# Local development only. Manage this configuration with
+# scripts/cern-coredns-local.sh so that other entries in the shared
+# coredns-custom ConfigMap are preserved.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  cern-reverse.server: |
+    # Forward CERN reverse-DNS zones to the DNS servers provided by the VPN.
+    # HTCondor needs these PTR records to construct Kerberos service principals.
+    138.137.in-addr.arpa:53 {
+        errors
+        cache 30
+        forward . 137.138.16.5 137.138.17.5
+    }
+    184.188.in-addr.arpa:53 {
+        errors
+        cache 30
+        forward . 137.138.16.5 137.138.17.5
+    }
+    185.188.in-addr.arpa:53 {
+        errors
+        cache 30
+        forward . 137.138.16.5 137.138.17.5
+    }

--- a/helm/configurations/values-dev.yaml
+++ b/helm/configurations/values-dev.yaml
@@ -40,6 +40,14 @@ components:
     image: docker.io/reanahub/reana-workflow-validator
   reana_job_controller:
     image: docker.io/reanahub/reana-job-controller
+    # For local HTCondor testing (for example, with Colima/k3s on
+    # macOS), enable the htcondorcern entry in the compute_backends list
+    # below and ensure that the cluster DNS can resolve CERN batch-host
+    # PTR records through the DNS servers provided by the CERN VPN. Use
+    # a concrete WTFIS endpoint and disable URL resolution, since the
+    # default wtfis.cern.ch discovery used on LXPLUS may not work from a
+    # local Kubernetes cluster.
+    #
     # For local Slurm testing, enable the slurmcern entry in the
     # compute_backends list below and connect to a concrete Slurm gate
     # node instead of the load-balanced hostname, so that SSH GSSAPI can
@@ -47,7 +55,13 @@ components:
     # SLURM_GSS_HOSTNAME can pin the Kerberos service principal
     # explicitly, but its value must match the gate node that the SSH
     # connection actually reaches.)
+    #
+    # Uncomment the environment clause and the variables of whichever
+    # backends you would like to test.
     # environment:
+    #   MYSCHEDD_WTFIS_ENDPOINT: https://batchkeeper1.cern.ch:9008
+    #   MYSCHEDD_WTFIS_RO_ENDPOINT: http://batchkeeper1.cern.ch:9009
+    #   MYSCHEDD_WTFIS_RESOLVE_URL: "false"
     #   SLURM_HOSTNAME: slurmgate01.cern.ch
   reana_message_broker:
     image: docker.io/reanahub/reana-message-broker

--- a/helm/configurations/values-dev.yaml
+++ b/helm/configurations/values-dev.yaml
@@ -42,11 +42,11 @@ components:
     image: docker.io/reanahub/reana-job-controller
     # For local HTCondor testing (for example, with Colima/k3s on
     # macOS), enable the htcondorcern entry in the compute_backends list
-    # below and ensure that the cluster DNS can resolve CERN batch-host
-    # PTR records through the DNS servers provided by the CERN VPN. Use
-    # a concrete WTFIS endpoint and disable URL resolution, since the
-    # default wtfis.cern.ch discovery used on LXPLUS may not work from a
-    # local Kubernetes cluster.
+    # below. Run scripts/cern-coredns-local.sh install to configure the
+    # cluster DNS to resolve CERN batch-host PTR records through the DNS
+    # servers provided by the CERN VPN. Use a concrete WTFIS endpoint and
+    # disable URL resolution, since the default wtfis.cern.ch discovery
+    # used on LXPLUS may not work from a local Kubernetes cluster.
     #
     # For local Slurm testing, enable the slurmcern entry in the
     # compute_backends list below and connect to a concrete Slurm gate

--- a/scripts/cern-coredns-local.sh
+++ b/scripts/cern-coredns-local.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+# Manage CERN reverse-DNS forwarding for local k3s development clusters.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly COREDNS_NAMESPACE="kube-system"
+readonly COREDNS_CONFIGMAP="coredns-custom"
+readonly COREDNS_DEPLOYMENT="coredns"
+readonly COREDNS_DATA_KEY="cern-reverse.server"
+SCRIPT_DIRECTORY="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+readonly SCRIPT_DIRECTORY
+readonly MANIFEST_PATH="${SCRIPT_DIRECTORY}/../etc/cern-coredns-local.yaml"
+
+usage() {
+    echo "Usage: $0 {install|status|remove}"
+    echo
+    echo "Manage CERN reverse-DNS forwarding in a local k3s cluster."
+    echo "The cluster must be connected to the CERN VPN."
+}
+
+print_error() {
+    echo "Error: $*" >&2
+}
+
+require_kubectl() {
+    if ! command -v kubectl >/dev/null 2>&1; then
+        print_error "kubectl is required."
+        exit 1
+    fi
+}
+
+check_supported_cluster() {
+    local corefile
+
+    if ! corefile=$(kubectl get configmap coredns \
+        --namespace "${COREDNS_NAMESPACE}" \
+        --output go-template='{{ index .data "Corefile" }}'); then
+        print_error "Cannot read the CoreDNS configuration."
+        exit 1
+    fi
+
+    if [[ "${corefile}" != *'import /etc/coredns/custom/*.server'* ]]; then
+        print_error "CoreDNS does not import coredns-custom server files."
+        print_error "This helper currently supports local k3s clusters only."
+        exit 1
+    fi
+}
+
+get_installed_fragment() {
+    kubectl get configmap "${COREDNS_CONFIGMAP}" \
+        --namespace "${COREDNS_NAMESPACE}" \
+        --ignore-not-found \
+        --output "go-template={{ with .data }}{{ with index . \"${COREDNS_DATA_KEY}\" }}{{ . }}{{ end }}{{ end }}"
+}
+
+restart_coredns() {
+    kubectl rollout restart "deployment/${COREDNS_DEPLOYMENT}" \
+        --namespace "${COREDNS_NAMESPACE}"
+    kubectl rollout status "deployment/${COREDNS_DEPLOYMENT}" \
+        --namespace "${COREDNS_NAMESPACE}" \
+        --timeout 60s
+}
+
+install_configuration() {
+    local configmap
+
+    check_supported_cluster
+    configmap=$(kubectl get configmap "${COREDNS_CONFIGMAP}" \
+        --namespace "${COREDNS_NAMESPACE}" \
+        --ignore-not-found \
+        --output name)
+
+    # Create the ConfigMap when it is absent, and merge the fragment into it
+    # otherwise. A merge patch keeps unrelated entries, whilst a server-side
+    # apply would prune them when the ConfigMap was created by a client-side
+    # apply.
+    if [[ -z "${configmap}" ]]; then
+        kubectl create --filename "${MANIFEST_PATH}"
+    else
+        kubectl patch configmap "${COREDNS_CONFIGMAP}" \
+            --namespace "${COREDNS_NAMESPACE}" \
+            --type merge \
+            --patch-file "${MANIFEST_PATH}"
+    fi
+
+    restart_coredns
+    echo "CERN reverse-DNS forwarding is installed."
+}
+
+show_status() {
+    local fragment
+    fragment=$(get_installed_fragment)
+
+    if [[ -n "${fragment}" ]]; then
+        echo "CERN reverse-DNS forwarding is installed."
+        kubectl get "deployment/${COREDNS_DEPLOYMENT}" \
+            --namespace "${COREDNS_NAMESPACE}"
+    else
+        echo "CERN reverse-DNS forwarding is not installed."
+    fi
+}
+
+remove_configuration() {
+    local fragment
+    fragment=$(get_installed_fragment)
+
+    if [[ -z "${fragment}" ]]; then
+        echo "CERN reverse-DNS forwarding is not installed."
+        return
+    fi
+
+    kubectl patch configmap "${COREDNS_CONFIGMAP}" \
+        --namespace "${COREDNS_NAMESPACE}" \
+        --type json \
+        --patch "[{\"op\":\"remove\",\"path\":\"/data/${COREDNS_DATA_KEY}\"}]"
+    restart_coredns
+    echo "CERN reverse-DNS forwarding is removed."
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 1
+fi
+
+case "$1" in
+-h | --help)
+    usage
+    exit 0
+    ;;
+install | status | remove) ;;
+*)
+    usage
+    exit 1
+    ;;
+esac
+
+require_kubectl
+echo "Using Kubernetes context: $(kubectl config current-context)"
+
+case "$1" in
+install) install_configuration ;;
+status) show_status ;;
+remove) remove_configuration ;;
+esac


### PR DESCRIPTION
Add a helper for installing, inspecting, and removing a dedicated
CoreDNS fragment that forwards CERN reverse-DNS zones to the name
servers available through the CERN VPN. This lets HTCondor resolve PTR
records needed to construct Kerberos service principals.

Limit the helper to compatible k3s configurations, preserve unrelated
entries in the shared ConfigMap, and restart CoreDNS after changes.
Reference the helper from the local-development Helm values.

