### PR TITLE
fix(helm): update Traefik chart repository

### DIFF
--- a/helm/reana/Chart.yaml
+++ b/helm/reana/Chart.yaml
@@ -32,7 +32,7 @@ kubeVersion: ">= 1.21.0-0"
 dependencies:
   - name: traefik
     version: 31.1.0
-    repository: https://helm.traefik.io/traefik
+    repository: https://traefik.github.io/charts
     condition: traefik.enabled
     tags:
       - ingress


### PR DESCRIPTION
According to the [traefik documentation](https://doc.traefik.io/traefik/setup/kubernetes/) the chart repository that should be used is: https://traefik.github.io/charts The old one we used: https://helm.traefik.io/traefik/index.yaml is no longer reachable.

Closes #991