### PR TITLE
ci(release-please): upgrade action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024, 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
 on:
   push:
     branches:
@@ -6,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 name: release-please
@@ -14,7 +21,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           config-file: .release-please-config.json
           target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
Replace the archived `google-github-actions` action with the maintained
`googleapis` v5 action.

Preserve the existing Release Please configuration and target branches.
Grant the recommended `issues: write` workflow permission and add the
standard REANA copyright header.

Closes reanahub/reana#997
